### PR TITLE
Update 2011-04-19-ConstructorstrategiesforAutoFixture.html

### DIFF
--- a/_posts/2011-04-19-ConstructorstrategiesforAutoFixture.html
+++ b/_posts/2011-04-19-ConstructorstrategiesforAutoFixture.html
@@ -23,4 +23,3 @@ title: "Constructor strategies for AutoFixture"
 <p align="left">In this unit test, the only change from the previous is that instead of assigning the GreedyConstructorQuery specifically to Bastard, it's now assigned as the new default strategy. All specimens created by AutoFixture will be created by invoking their most greedy constructor.</p>
 <p align="left">As always I find the default behavior more attractive, but the option to change behavior is there if you need it.</p>
 </div>
-	


### PR DESCRIPTION
Replace 3 occurrences of obsolete 'ConstructorInvoker' with 'MethodInvoker', as recommended by latest AutoFixture intellisense.
