### PR TITLE
Comment on 2013-01-10-RoleInterfaceRoleHint.html

### DIFF
--- a/_posts/2013-01-10-RoleInterfaceRoleHint.html
+++ b/_posts/2013-01-10-RoleInterfaceRoleHint.html
@@ -94,4 +94,28 @@ title: "Role Interface Role Hint"
 	As the name implies, a Role Interface can be used as a Role Hint. However, you must be wary of pulling in disconnected architectural concerns. Thus, while a class can implement several Role Interfaces, it should only implement interfaces defined in appropriate layers. (The word 'layer' here is used in a loose sense, but the same considerations apply for <a href="http://c2.com/cgi/wiki?PortsAndAdaptersArchitecture">Ports and Adapters</a>: don't mix Port types and Adapter types.)
 </p>
 </div>
+<div id="comments">
+<hr>
+<h2 id="comments-header">
+	Comments
+</h2>
+
+</div>
+
+<div class="comment">
+<div class="comment-author"><a href="http://blogs.msdn.com">Jeff Soper</a></div>
+<div class="comment-content">
+<p>
+	Could you expand upon how you might implement the fall-through mechanism you mentioned in your IShippingCostCalculatorFactory implementation, where more than one candidate can handle the shippingMethod?
+</p>
+<p>
+	How would you sort your IEnumerable&lt;IBasketCalculator&gt; candidates in GetCalculator() so that the candidate returned by First() is the one specifically meant to handle the ShippingMethod when one exists, and the default implementation when a specific one doesn't exist?
+</p>
+<p>
+	I considered using FirstOrDefault(), then returning the default implementation if the result of the query was nothing, but my default IHandleShippingMethod implementation always returns True from CanHandle() - I don't know what other value it could return.
+</p>
+</div>
+<div class="comment-date">2013-08-14 15:37 UTC</div>
+</div>
+</div>
 	


### PR DESCRIPTION
Asked question about how to implement a fall-through mechanism in the  GetCalculator method shown in the post. If the formatting is not what you want, here's the gist of what I was asking:

Could you expand upon how you might implement the fall-through mechanism you mentioned in your IShippingCostCalculatorFactory implementation, where more than one candidate can handle the shippingMethod?

How would you sort your IEnumerable<IBasketCalculator> candidates in GetCalculator() so that the candidate returned by First() is the one specifically meant to handle the ShippingMethod when one exists, and the default implementation when a specific one doesn't exist?

I considered using FirstOrDefault(), then returning the default implementation if the result of the query was nothing, but my default IHandleShippingMethod implementation always returns True from CanHandle() - I don't know what other value it could return.
