### PR TITLE
Comment to address a possible solution to "common" version attributes.

### DIFF
--- a/_posts/2013-12-10-semantic-versioning-with-continuous-deployment.html
+++ b/_posts/2013-12-10-semantic-versioning-with-continuous-deployment.html
@@ -104,3 +104,146 @@ tags: [Productivity]
 		The version number is kept in the source control system, together with the source code. It's not the realm of a Build Server.
 	</p>
 </div>
+<div id="comments">
+	<hr>
+	<h2 id="comments-header">
+			Comments
+	</h2>
+	<div class="comment">
+		<div class="comment-author"><a href="https://github.com/nuggetboy">Chris Simmons</a></div>
+		<div class="comment-content">
+			<p>
+				Mark, I also have a Visual Studio solution or two with multiple AssemblyInfo.cs files (although not as many
+				as you) and wish to use a common version number for each contained project.  I came up with the following
+				approach, which doesn't require any automation.  It only uses the Visual Studio/MSBuild
+				&lt;Link /&gt; functionality.  The key is simply to use the
+				<a href="http://msdn.microsoft.com/en-us/library/windowsphone/develop/jj714082(v=vs.105).aspx">Add As Link</a>
+				functionality for common attributes.
+			</p>
+			<p>
+				Simply put, I split out the common information (Version info and company/copyright/trademark info) from
+				projects' AssemblyInfo.cs files into another file called SolutionAssemblyInfo.cs.  I place that file at the
+				root of the solution (outside of any project folders).  Then, for each project, remove the version information
+				from the AssemblyInfo.cs file and use the 'Add As Link' function in the 'Add Existing Item'
+				function in Visual Studio to link to the SolutionAssemblyInfo.cs file.  With that, you have only one place
+				to update the version information: the SolutionAssemblyInfo.cs file.  Any change to that version
+				information will be included in each project.
+			</p>
+			<p>
+				That might be enough information to get you going, but if not, I'll expand and outline the specific process.
+				The basic idea is to look at the AssemblyInfo.cs file as having two sets of metadata:
+				<ul>
+					<li>Metadata specific to the project itself:
+						<ul>
+							<li><a href="http://msdn.microsoft.com/en-us/library/system.reflection.assemblytitleattribute.aspx">[AssemblyTitle]</a></li>
+							<li><a href="http://msdn.microsoft.com/en-us/library/system.reflection.AssemblyDescriptionattribute.aspx">[AssemblyDescription]</a></li>
+							<li><a href="http://msdn.microsoft.com/en-us/library/system.reflection.AssemblyConfigurationattribute.aspx">[AssemblyConfiguration]</a></li>
+							<li><a href="http://msdn.microsoft.com/en-us/library/system.reflection.AssemblyProductattribute.aspx">[AssemblyProduct]</a></li>
+							<li><a href="http://msdn.microsoft.com/en-us/library/system.reflection.AssemblyCultureattribute.aspx">[AssemblyCulture]</a></li>
+							<li><a href="http://msdn.microsoft.com/en-us/library/System.Runtime.InteropServices.ComVisibleAttribute.aspx">[ComVisible]</a></li>
+							<li><a href="http://msdn.microsoft.com/en-us/library/System.Runtime.InteropServices.GuidAttribute.aspx">[Guid]</a></li>
+						</ul>
+					</li>
+					<li>Metadata that really should be shared amongst all projects in the solution.  Specifically:
+						<ul>
+							<li><a href="http://msdn.microsoft.com/en-us/library/system.reflection.assemblyversionattribute.aspx">[AssemblyVersion]</a></li>
+							<li><a href="http://msdn.microsoft.com/en-us/library/system.reflection.assemblyfileversionattribute.aspx">[AssemblyFileVersion]</a></li>
+							<li><a href="http://msdn.microsoft.com/en-us/library/system.reflection.assemblyinformationalversionattribute.aspx">[AssemblyInformationalVersion]</a> (Although, depending on your needs, you may choose to leave this attribute in the project-specifics AssemblyInfo.cs)</li>
+							<li><a href="http://msdn.microsoft.com/en-us/library/system.reflection.AssemblyCompanyattribute.aspx">[AssemblyCompany]</a></li>
+							<li><a href="http://msdn.microsoft.com/en-us/library/system.reflection.AssemblyCopyrightattribute.aspx">[AssemblyCopyright]</a></li>
+							<li><a href="http://msdn.microsoft.com/en-us/library/system.reflection.AssemblyTrademarkattribute.aspx">[AssemblyTrademark]</a></li>
+						</ul>
+					</li>
+				</ul>
+			</p>
+			<p>
+				You can separate the shared metadata into a common AssemblyInfo.cs
+				file.  Then, by linking to that common file in each project (as opposed to including), you won't need
+				to update 28 files; you'll only need to update the common one.
+			</p>
+			<p>
+				Assume I have the following AssemblyInfo.cs file for one of my projects:
+				<blockquote><pre>
+	// AssemblyInfo.cs
+	using System.Reflection;
+	using System.Runtime.InteropServices;
+
+	[assembly: AssemblyTitle("SampleProject")]
+	[assembly: AssemblyDescription("")]
+	[assembly: AssemblyConfiguration("")]
+	[assembly: AssemblyCompany("Company Name")]
+	[assembly: AssemblyProduct("SampleProject")]
+	[assembly: AssemblyCopyright("Copyright (c) Company Name 2013")]
+	[assembly: AssemblyTrademark("")]
+	[assembly: AssemblyCulture("")]
+
+	[assembly: ComVisible(false)]
+
+	[assembly: Guid("7ae5f3ab-e519-4c44-bb65-489305fc36b0")]
+
+	[assembly: AssemblyVersion("1.0.0.0")]
+	[assembly: AssemblyFileVersion("1.0.0.0")]
+				</pre></blockquote>
+
+				I split this out into two files:
+				<blockquote><pre>
+	// AssemblyInfo.cs
+	using System.Reflection;
+	using System.Runtime.InteropServices;
+
+	[assembly: AssemblyTitle("SampleProject")]
+	[assembly: AssemblyDescription("")]
+	[assembly: AssemblyConfiguration("")]
+	[assembly: AssemblyProduct("SampleProject")]
+	[assembly: AssemblyCulture("")]
+
+	[assembly: ComVisible(false)]
+
+	[assembly: Guid("7ae5f3ab-e519-4c44-bb65-489305fc36b0")]
+				</pre></blockquote>
+	and
+				<blockquote><pre>
+	// SolutionAssemblyInfo.cs
+	using System.Reflection;
+
+	[assembly: AssemblyCompany("Company Name")]
+	[assembly: AssemblyCopyright("Copyright (c) Company Name 2013")]
+	[assembly: AssemblyTrademark("")]
+
+	[assembly: AssemblyVersion("1.0.0.0")]
+	[assembly: AssemblyFileVersion("1.0.0.0")]
+	// Depending on your needs, AssemblyInformationalVersion as well?
+				</pre></blockquote>
+			</p>
+			<p>
+				The SolutionAssemblyInfo.cs goes in the root of your solution and should
+				initially not be included in any projects.  Then, for each project:
+				<ul>
+					<li>Remove all attributes that went into SolutionAssemblyInfo.cs</li>
+					<li>Right-click the project and &quot;Add..., Existing Item...&quot;</li>
+					<li>Navigate to the SolutionAssemblyInfo.cs file</li>
+					<li>Instead of clicking the &quot;Add&quot; button, click the little drop-down on it and select
+					&quot;Add As Link&quot;</li>
+					<li>If you want the new linked SolutionAssemblyInfo.cs file to show up under the Properties folder
+					(like the AssesmblyInfo.cs file), just drag it from the project root into the Properties folder.
+					Unfortunately, you can't simply add the link to the Properties folder directly (at least not in VS 2012).</li>
+				</ul>
+
+				(Note: it looks like there may be an easier method in VS 2012+ only to get the &quot;Add As Link&quot; function, mentioned
+				<a href="http://stackoverflow.com/a/12858818/208990">on StackOverflow</a>, by simply dragging and dropping while
+				holding the Alt key.)
+			</p>
+			<p>
+				That's it.  Now, you will be able to access this SolutionAssemblyInfo.cs file from any of your projects
+				and any changes you make to that file will persist into the linked file, being shared with all projects.
+			</p>
+			<p>
+				The downside to this, as opposed to an automation solution, is that you need to repeat this process
+				(starting with &quot;Remove all attributes...&quot;) for all new projects you add.  However, in my
+				opinion, that's a small, one-time-per-project price to pay.  With the above, you let the established
+				tool work for you with built-in features.
+			</p>
+		</div>
+		<div class="comment-date">2013-12-10 18:00 UTC</div>
+	</div>
+</div>


### PR DESCRIPTION
In response to, "The only problem is that AutoFixture has 28 AssemblyInfo files (each with two version attributes) that I must update and keep in sync."
