### PR TITLE
Add comment re: NuGet package destination

### DIFF
--- a/_posts/2013-12-11-zerotonine.html
+++ b/_posts/2013-12-11-zerotonine.html
@@ -25,3 +25,19 @@ tags: [Productivity, F#]
 		It's available <a href="https://www.nuget.org/packages/Zero29">via NuGet</a>, and is written in F#.
 	</p>
 </div>
+
+<div id="comments">
+        <hr>
+        <h2 id="comments-header">
+                Comments
+        </h2>
+        <div class="comment">
+                <div class="comment-author">Jeff Soper</div>
+                <div class="comment-content">
+                	<p>Can you clarify where one would install this when adding the NuGet package to a solution of several projects?</p>
+                	<p>Your documentation says that it will update AssemblyInfo files in all subdirectories beneath the present working directory, but I thought that NuGet packages are applied at a project level, not at a solution level. So, wouldn't this mean that I would be running your tool from one of the many project directories, in which only that project's AssemblyInfo file would be affected?</p>
+                	<p>I'm sure I'm not grasping something simple, but I'm anxious to incorporate this into my workflow!</p>
+                </div>
+                <div class="comment-date">2014-01-23 19:26 UTC</div>
+        </div>
+</div>


### PR DESCRIPTION
Can you clarify where one would install this when adding the NuGet package to a solution of several projects?

Your documentation says that it will update AssemblyInfo files in all subdirectories beneath the present working directory, but I thought that NuGet packages are applied at a project level, not at a solution level. So, wouldn't this mean that I would be running your tool from one of the many project directories, in which only that project's AssemblyInfo file would be affected?

I'm sure I'm not grasping something simple, but I'm anxious to incorporate this into my workflow!
