### PR TITLE
Rename CommerceObjectContext to CommerceContext

### DIFF
--- a/_posts/2014-06-02-captive-dependency.html
+++ b/_posts/2014-06-02-captive-dependency.html
@@ -56,9 +56,9 @@ tags: [Dependency Injection]
   <p>
     <pre style="font-family:Consolas;font-size:13;color:black;"><span style="color:blue;">public</span>&nbsp;<span style="color:blue;">class</span>&nbsp;<span style="color:#2b91af;">SqlProductRepository</span>&nbsp;:&nbsp;<span style="color:#2b91af;">IProductRepository</span>
 {
-&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">private</span>&nbsp;<span style="color:blue;">readonly</span>&nbsp;<span style="color:#2b91af;">CommerceObjectContext</span>&nbsp;context;
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">private</span>&nbsp;<span style="color:blue;">readonly</span>&nbsp;<span style="color:#2b91af;">CommerceContext</span>&nbsp;context;
  
-&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">public</span>&nbsp;SqlProductRepository(<span style="color:#2b91af;">CommerceObjectContext</span>&nbsp;context)
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">public</span>&nbsp;SqlProductRepository(<span style="color:#2b91af;">CommerceContext</span>&nbsp;context)
 &nbsp;&nbsp;&nbsp;&nbsp;{
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">this</span>.context&nbsp;=&nbsp;context;
 &nbsp;&nbsp;&nbsp;&nbsp;}
@@ -67,7 +67,7 @@ tags: [Dependency Injection]
 }</pre>
   </p>
   <p>
-    The CommerceObjectContext class derives from the Entity Framework <a href="http://msdn.microsoft.com/en-us/library/system.data.entity.dbcontext.aspx">DbContext</a> class, which, last time I looked, isn't thread-safe. Thus, when used in a web application, it's very important to create a new instance of the CommerceObjectContext class for every request, because otherwise you may experience errors. What's worse is that these errors will be threading errors, so you'll not discover them when you test your web application on your development machine, but when in production, you'll have multiple concurrent requests, and <em>then</em> the application will crash (or perhaps 'just' lose data, which is even worse).
+    The CommerceContext class derives from the Entity Framework <a href="http://msdn.microsoft.com/en-us/library/system.data.entity.dbcontext.aspx">DbContext</a> class, which, last time I looked, isn't thread-safe. Thus, when used in a web application, it's very important to create a new instance of the CommerceContext class for every request, because otherwise you may experience errors. What's worse is that these errors will be threading errors, so you'll not discover them when you test your web application on your development machine, but when in production, you'll have multiple concurrent requests, and <em>then</em> the application will crash (or perhaps 'just' lose data, which is even worse).
   </p>
   <p>
     (As a side note I should point out that I've used neither Entity Framework nor the Repository pattern for years now, but the example explains the problem well, in a context familiar to most people.)
@@ -87,10 +87,10 @@ container.Bind&lt;<span style="color:#2b91af;">ProductService</span>&gt;().ToSel
 container.Bind&lt;<span style="color:#2b91af;">IProductRepository</span>&gt;().To&lt;<span style="color:#2b91af;">SqlProductRepository</span>&gt;();</pre>
   </p>
   <p>
-    With Ninject you don't need to register concrete types, so there's no reason to register the CommerceObjectContext class; it wouldn't be necessary to register the ProductService either, if it wasn't for the fact that you'd like it to have the Singleton lifestyle. Ninject's default lifestyle is Transient, so that's the lifestyle of both SqlProductRepository and CommerceObjectContext.
+    With Ninject you don't need to register concrete types, so there's no reason to register the CommerceContext class; it wouldn't be necessary to register the ProductService either, if it wasn't for the fact that you'd like it to have the Singleton lifestyle. Ninject's default lifestyle is Transient, so that's the lifestyle of both SqlProductRepository and CommerceContext.
   </p>
   <p>
-    As you've probably already predicted, the Singleton lifestyle of ProductService captures both the direct dependency IProductRepository, and the indirect dependency CommerceObjectContext:
+    As you've probably already predicted, the Singleton lifestyle of ProductService captures both the direct dependency IProductRepository, and the indirect dependency CommerceContext:
   </p>
   <p>
     <pre style="font-family:Consolas;font-size:13;color:black;"><span style="color:blue;">var</span>&nbsp;actual1&nbsp;=&nbsp;container.Get&lt;<span style="color:#2b91af;">ProductService</span>&gt;();
@@ -103,7 +103,7 @@ container.Bind&lt;<span style="color:#2b91af;">IProductRepository</span>&gt;().T
     The repositories are the same because <code>actual1</code> and <code>actual2</code> are the same instance, so naturally, their constituent components are also the same.
   </p>
   <p>
-    This is problematic because CommerceObjectContext (deriving from DbContext) isn't thread-safe, so if you resolve ProductService from multiple concurrent requests (which you could easily do in a web application), you'll have a problem.
+    This is problematic because CommerceContext (deriving from DbContext) isn't thread-safe, so if you resolve ProductService from multiple concurrent requests (which you could easily do in a web application), you'll have a problem.
   </p>
   <p>
     The immediate fix is to make this entire sub-graph Transient:
@@ -153,11 +153,11 @@ container.Bind&lt;<span style="color:#2b91af;">IProductRepository</span>&gt;().T
     <pre style="font-family:Consolas;font-size:13;color:black;"><span style="color:blue;">var</span>&nbsp;builder&nbsp;=&nbsp;<span style="color:blue;">new</span>&nbsp;<span style="color:#2b91af;">ContainerBuilder</span>();
 builder.RegisterType&lt;<span style="color:#2b91af;">ProductService</span>&gt;().SingleInstance();
 builder.RegisterType&lt;<span style="color:#2b91af;">SqlProductRepository</span>&gt;().As&lt;<span style="color:#2b91af;">IProductRepository</span>&gt;();
-builder.RegisterType&lt;<span style="color:#2b91af;">CommerceObjectContext</span>&gt;();
+builder.RegisterType&lt;<span style="color:#2b91af;">CommerceContext</span>&gt;();
 <span style="color:blue;">var</span>&nbsp;container&nbsp;=&nbsp;builder.Build();</pre>
   </p>
   <p>
-    Like Ninject, the default lifestyle for Autofac is Transient, so you don't have to explicitly configure the lifetimes of SqlProductRepository or CommerceObjectContext. On the other hand, Autofac requires you to register all services in use, even when they're concrete classes; this is the reason you see a registration statement for CommerceObjectContext as well.
+    Like Ninject, the default lifestyle for Autofac is Transient, so you don't have to explicitly configure the lifetimes of SqlProductRepository or CommerceContext. On the other hand, Autofac requires you to register all services in use, even when they're concrete classes; this is the reason you see a registration statement for CommerceContext as well.
   </p>
   <p>
     The problem is exactly the same as with Ninject:
@@ -176,7 +176,7 @@ builder.RegisterType&lt;<span style="color:#2b91af;">CommerceObjectContext</span
     <pre style="font-family:Consolas;font-size:13;color:black;"><span style="color:blue;">var</span>&nbsp;builder&nbsp;=&nbsp;<span style="color:blue;">new</span>&nbsp;<span style="color:#2b91af;">ContainerBuilder</span>();
 builder.RegisterType&lt;<span style="color:#2b91af;">ProductService</span>&gt;();
 builder.RegisterType&lt;<span style="color:#2b91af;">SqlProductRepository</span>&gt;().As&lt;<span style="color:#2b91af;">IProductRepository</span>&gt;();
-builder.RegisterType&lt;<span style="color:#2b91af;">CommerceObjectContext</span>&gt;();
+builder.RegisterType&lt;<span style="color:#2b91af;">CommerceContext</span>&gt;();
 <span style="color:blue;">var</span>&nbsp;container&nbsp;=&nbsp;builder.Build();
  
 <span style="color:blue;">var</span>&nbsp;actual1&nbsp;=&nbsp;container.Resolve&lt;<span style="color:#2b91af;">ProductService</span>&gt;();


### PR DESCRIPTION
Having `CommerceObjectContext` inheriting DbContext is inconsistent.
ObjectContext is legacy from LINQ to SQL and DbContext is from EF 4+.
More consistent would be to call it `CommerceDbContext`, or even more generic and library-independent - `CommerceContext`.
