### PR TITLE
make all images max 100% width

### DIFF
--- a/assets/themes/ploeh/css/style.css
+++ b/assets/themes/ploeh/css/style.css
@@ -2,6 +2,9 @@
 html, body {
   background-color: #eee;
 }
+
+img {max-width:100%}
+
 .navbar {
   margin-bottom: 0;
 }


### PR DESCRIPTION
When the screen size is smaller than any given image, this ensures the image is sized to a maximum width that fits within it's container element.
