### PR TITLE
.Create should not use a hard coded value

### DIFF
--- a/_posts/2013-10-23-mocks-for-commands-stubs-for-queries.html
+++ b/_posts/2013-10-23-mocks-for-commands-stubs-for-queries.html
@@ -340,7 +340,7 @@ tags: [Unit Testing]
 {
 &nbsp;&nbsp;&nbsp; <span style="color: blue;">var</span> u = <span style="color: blue;">this</span>.userRepository.Read(userId);
 &nbsp;&nbsp;&nbsp; <span style="color: blue;">if</span> (u.Id == 0)
-&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; <span style="color: blue;">this</span>.userRepository.Create(1234);
+&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; <span style="color: blue;">this</span>.userRepository.Create(userId);
 &nbsp;&nbsp;&nbsp; <span style="color: blue;">return</span> u;
 }</pre>
 </div>


### PR DESCRIPTION
Is this a bug in the implementation?
