### PR TITLE
Question: instantiating UserName with lowercase

### DIFF
--- a/_posts/2015-01-19-from-primitive-obsession-to-domain-modelling.html
+++ b/_posts/2015-01-19-from-primitive-obsession-to-domain-modelling.html
@@ -351,4 +351,19 @@ everyone else from doing so, depending on what kind of email address is being pa
     </div>
     <div class="comment-date">2015-01-21 13:35 UTC</div>
   </div>
+ <div class="comment">
+<div class="comment-author">Jeff Soper</div>
+<div class="comment-content">
+<p>
+This question might be slightly besides the point, but I'm having trouble with the bit about UserName values being case-insensitive. I take that to mean that you can create a UserName with all uppercase, all lowercase, or any combination thereof, and they'll all be treated equally.
+</p>
+<p>
+To me, that doesn't mean that you have to pass in an uppercase-only value to the constructor (or TryParse() method, for that matter) in order to successfully instantiate a UserName. Was that your intent?
+</p>
+<p>
+I created a <a href="https://gist.github.com/Lumirris/fefc77e7abc655630124">Gist</a> with some tests to illustrate what I'm talking about: I can instantiate with "JEFF", but not with "jeff", using either the constructor directly or the TryParse method.
+</p>
+</div>
+<div class="comment-date">2015-01-22 17:27 UTC</div>
+</div>  
 </div>


### PR DESCRIPTION
Although UserName is stated to be case-insensitive, does this necessarily mean that one must pass all uppercase to the constructor? That doesn't seem right.