### PR TITLE
Fixed Typos

### DIFF
--- a/_posts/2015-04-13-less-is-more-language-features.html
+++ b/_posts/2015-04-13-less-is-more-language-features.html
@@ -98,7 +98,7 @@ tags: [Languages]
     The problem with exceptions is that this mechanism is really only <a href="http://c2.com/cgi/wiki?DontUseExceptionsForFlowControl">GOTO statements in disguise</a> - and we've already learned that GOTO is considered harmful.
   </p>
   <p>
-    A better approach is to use a <a href="http://en.wikipedia.org/wiki/Tagged_union">sum type</a> to indicate <em>either</em> <a href="http://fsharpforfunandprofit.com/posts/recipe-part2">success of failure in a composable form</a>.
+    A better approach is to use a <a href="http://en.wikipedia.org/wiki/Tagged_union">sum type</a> to indicate <em>either</em> <a href="http://fsharpforfunandprofit.com/posts/recipe-part2">success or failure in a composable form</a>.
   </p>
   <p>
     <strong>Pointers</strong>
@@ -125,7 +125,7 @@ tags: [Languages]
     <strong>Null pointers</strong>
   </p>
   <p>
-    Nulls are some of the most misunderstood language constructs. There's nothing wrong with the concept of a value that may or may not be present. Many great programming languages have this concept. In Haskell, it's called <em>Maybe</em>; in F#, it's called <em>option</em>; in T-SQL it's called <em>null</em>. What's common in all these languages is that it's an <em>opt-in</em> language feature: you can declare a value as being 'nullable', but by default, <em>it isn't</em> (nullable).
+    Nulls are one of the most misunderstood language constructs. There's nothing wrong with the concept of a value that may or may not be present. Many great programming languages have this concept. In Haskell, it's called <em>Maybe</em>; in F#, it's called <em>option</em>; in T-SQL it's called <em>null</em>. What's common in all these languages is that it's an <em>opt-in</em> language feature: you can declare a value as being 'nullable', but by default, <em>it isn't</em> (nullable).
   </p>
   <p>
     However, due to <a href="http://www.infoq.com/presentations/Null-References-The-Billion-Dollar-Mistake-Tony-Hoare">Tony Hoare's self-admitted billion-dollar mistake</a>, mainstream languages have null pointers: C, C++, Java, C#. The problem isn't the <em>concept</em> of 'null', but rather that everything <em>can</em> be null, which makes it impossible to distinguish between the cases where null is an appropriate and expected value, from the cases where null is a defect.
@@ -143,7 +143,7 @@ tags: [Languages]
     <strong>Mutation</strong>
   </p>
   <p>
-    A central concept in Procedural, Imperative, and Object-Oriented languages is that you can change the value of a variable while executing your program. That's the reason it's called a <em>variable</em>. This seems intuitive, since a CPU contains registers, and what you actually do when you execute a program is that you move values in and out of those registers. It's also intuitive because the purpose of most programs is to change the state of the world: Store a record in a database. Send and email. Repaint the screen. Print a document. Etc.
+    A central concept in Procedural, Imperative, and Object-Oriented languages is that you can change the value of a variable while executing your program. That's the reason it's called a <em>variable</em>. This seems intuitive, since a CPU contains registers, and what you actually do when you execute a program is that you move values in and out of those registers. It's also intuitive because the purpose of most programs is to change the state of the world: Store a record in a database. Send an email. Repaint the screen. Print a document. Etc.
   </p>
   <p>
     However, it turns out that mutation is also a large source of defects in software, because it makes it much harder to reason about code. Consider a line of C# code like this:
@@ -152,7 +152,7 @@ tags: [Languages]
     <pre style="font-family:Consolas;font-size:13;color:black;"><span style="color:blue;">var</span>&nbsp;r&nbsp;=&nbsp;<span style="color:blue;">this</span>.mapper.Map(rendition);</pre>
   </p>
   <p>
-    When the Map method returns, have <code>rendition</code> been modified? Well, if you follow <a href="http://en.wikipedia.org/wiki/Command%E2%80%93query_separation">Command Query Separation</a>, it shouldn't, but the only way you can be sure is to review the implementation of the Map method. What if that method exhibits the same problem, by calling into other methods that <em>could</em> mutate the state of the application? There's nothing in C# (or Java, or C++, etc.) that prevents this from happening.
+    When the <code>Map</code> method returns, has <code>rendition</code> been modified? Well, if you follow <a href="http://en.wikipedia.org/wiki/Command%E2%80%93query_separation">Command Query Separation</a>, it shouldn't, but the only way you can be sure is to review the implementation of the Map method. What if that method exhibits the same problem, by calling into other methods that <em>could</em> mutate the state of the application? There's nothing in C# (or Java, or JavaScript, etc.) that prevents this from happening.
   </p>
   <p>
     In a complicated program with a big call stack, it's impossible to reason about the code, because <em>everything</em> could mutate, and once you have tens or hundreds of variables in play, you can no longer keep track of them. Did the <code>isDirty</code> flag change? Where? What about the <code>customerStatus</code>?
@@ -221,7 +221,7 @@ tags: [Languages]
     If you've ever done any sort of meta-programming in .NET or Java, you probably know what Reflection is. It's a set of APIs and language or platform features that enable you to inspect, query, manipulate, or emit code.
   </p>
   <p>
-    <em>Meta-programming</em> is an indispensable tool, so I'd be sorry to miss it. However, Reflection isn't the <em>only</em> way to enable meta-programming. Some languages are <a href="http://en.wikipedia.org/wiki/Homoiconicity">homoiconic</a>, which means that a program in such languages is structured as data, which itself can be queried and manipulated like all other data. Such languages don't need Reflection as a feature, because meta-programming is baked into the language, so to speak.
+    <em>Meta-programming</em> is an indispensable tool, so I'd be sorry to lose it. However, Reflection isn't the <em>only</em> way to enable meta-programming. Some languages are <a href="http://en.wikipedia.org/wiki/Homoiconicity">homoiconic</a>, which means that a program in such languages is structured as data, which itself can be queried and manipulated like any other data. Such languages don't need Reflection as a feature, because meta-programming is baked into the language, so to speak.
   </p>
   <p>
     In other words: Reflection is a language feature aimed at the goal of meta-programming. If meta-programming can be achieved via homoiconicity instead, it would imply that Reflection is a redundant feature.
@@ -230,7 +230,7 @@ tags: [Languages]
     <strong>Cyclic Dependencies</strong>
   </p>
   <p>
-    While it may be true that null pointers is the biggest single source of software defects, in my experience the greatest single source of unmaintainable code is <em>coupling</em>. One of the most problematic types of coupling is cyclic dependencies. In languages like C# and Java, cyclic dependencies are almost impossible to avoid.
+    While it may be true that null pointers are the biggest single source of software defects, in my experience the greatest single source of unmaintainable code is <em>coupling</em>. One of the most problematic types of coupling is cyclic dependencies. In languages like C# and Java, cyclic dependencies are almost impossible to avoid.
   </p>
   <p>
     Here's one of my own mistakes that I only discovered because I started to look for it: in the otherwise nice and maintainable <a href="https://github.com/GreanTech/AtomEventStore">AtomEventStore</a>, there's an interface called <a href="https://github.com/GreanTech/AtomEventStore/blob/master/AtomEventStore/IXmlWritable.cs">IXmlWritable</a>:


### PR DESCRIPTION
I know const isnt water tight but idiomatic C++ does use const to 'guarantee no changes'