### PR TITLE
Limiting Atom and RSS feeds to 10 posts

### DIFF
--- a/_includes/themes/ploeh/atom.xml
+++ b/_includes/themes/ploeh/atom.xml
@@ -11,7 +11,7 @@
  <subtitle>{{ site.tagline }}</subtitle> 
  <id>{{ site.production_url }}</id>
 
- {% for post in site.posts %}
+ {% for post in site.posts limit:10 %}
  <entry>
  	<title>{{ post.title }}</title>
    	<link rel="alternate" type="text/html" href="{{ site.production_url }}{{ post.url }}"/>   

--- a/_includes/themes/ploeh/atom.xml
+++ b/_includes/themes/ploeh/atom.xml
@@ -11,7 +11,7 @@
  <subtitle>{{ site.tagline }}</subtitle> 
  <id>{{ site.production_url }}</id>
 
- {% for post in site.posts limit:10 %}
+ {% for post in site.posts %}
  <entry>
  	<title>{{ post.title }}</title>
    	<link rel="alternate" type="text/html" href="{{ site.production_url }}{{ post.url }}"/>   

--- a/_includes/themes/ploeh/rss.xml
+++ b/_includes/themes/ploeh/rss.xml
@@ -10,7 +10,7 @@
     <pubDate>{{ site.time | date: "%a, %d %b %Y %H:%M:%S %Z" }}</pubDate>
     <lastBuildDate>{{ site.time | date: "%a, %d %b %Y %H:%M:%S %Z" }}</lastBuildDate>
 
-    {% for post in site.posts %}
+    {% for post in site.posts limit:10 %}
       <item>
         <title>{{ post.title }}</title>
         <link>{{ site.production_url }}{{ post.url }}</link>


### PR DESCRIPTION
As discussed on twitter and mentioned via my [blog](http://taeguk.co.uk/blog/dealing-with-newsblur-and-large-feeds/), NewsBlur has problems with large RSS / Atom feeds. Jekyll supports limiting the number of posts in the feed. I've picked 10 as an arbitrary number.