### PR TITLE
Typo: Pragma disable/restore mismatch

### DIFF
--- a/_posts/2015-09-21-public-types-hidden-in-plain-sight.html
+++ b/_posts/2015-09-21-public-types-hidden-in-plain-sight.html
@@ -94,7 +94,7 @@ tags: [Software Design]
 &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">var</span>&nbsp;sut&nbsp;=&nbsp;
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">new</span>&nbsp;<span style="color:#2b91af;">DurationStatistics</span>(
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;seconds.Select(s&nbsp;=&gt;&nbsp;<span style="color:#2b91af;">TimeSpan</span>.FromSeconds(s)).ToArray());
-<span style="color:blue;">#pragma</span>&nbsp;<span style="color:blue;">warning</span>&nbsp;<span style="color:blue;">restore</span>&nbsp;681
+<span style="color:blue;">#pragma</span>&nbsp;<span style="color:blue;">warning</span>&nbsp;<span style="color:blue;">restore</span>&nbsp;618
 &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">var</span>&nbsp;actual&nbsp;=&nbsp;sut.Average;
 &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:#2b91af;">Assert</span>.Equal(expectedSeconds,&nbsp;actual.TotalSeconds);
 }</pre>


### PR DESCRIPTION
This looks like a typo, assume it should be 618 both places instead of 681 on the restore.