### PR TITLE
added another comment to "Service Locator violates SOLID"

### DIFF
--- a/_posts/2014-05-15-service-locator-violates-solid.html
+++ b/_posts/2014-05-15-service-locator-violates-solid.html
@@ -174,4 +174,55 @@ tags: [Software Design, Dependency Injection]
     </div>
     <div class="comment-date">2016-01-07 19:16 UTC</div>
   </div>
+  <div class="comment">
+      <div class="comment-author"><a href="http://www.feo2x.com">Kenny Pflug</a></div>
+      <div class="comment-content">
+          <p>Dear Mark,</p>
+          <p>
+              I get the point that you are talking from the client's perspective - but even so, a client programming against a
+              Service Locator should be aware that it is programming against an abstraction of a Metaprogramming API
+              (and not an Object-Oriented API). If you think about the call to the Create method, then you basically say
+              "Give me an object graph with the specified type as the object graph root" as a client - how do you implement
+              this with the possibilities that OOP provides? You can't model this with classes, interfaces, and the means
+              of Procedural and Structural Programming that are integrated in OOP - because these techniques do not allow
+              you to treat code as data.
+          </p>
+          <p>
+              And again, your argument is based on the generic version of the Create method, but that shouldn't be the
+              point of focus. It is the non-generic version <code>object Create (Type type)</code> which clearly indicates
+              that it is a Metaprogramming API because of the Type parameter and the object return type -
+              <a href="https://msdn.microsoft.com/en-us/library/system.type.aspx">Type</a> is the entry point to .NET
+              Reflection and object is the only type the Service Locator can guarantee as the object graph is dynamically resolved
+              at runtime - no Strong Typing involved. The existence of the generic Create variation is merely justified
+              because software developers are lazy - they don't want to manually downcast the returned object to the type they
+              actually need. Well, one could argue that this comforts the Single Point of Truth / Don't repeat yourself
+              principles, too, as all information to create the object graph and to downcast the root object are derived
+              from the generic type argument, but that doesn't change the fact that Service Locator is a Metaprogramming API.
+          </p>
+          <p>
+              And that's why I solely used the term DI container throughout my previous comment, because Service Locator
+              is just the part of the API of a DI container that is concerned with resolving object graphs (and the
+              Metainformation to create these object graphs was registered beforehand). Sure, you can implement
+              Service Locators as a hard-wired registry of Singleton objects (or even Factories that create objects on the fly)
+              to circumvent the use of the Reflection API (although one probably had to use some sort of Type ID in this case,
+              maybe in form of a string or GUID). But honestly, these are half-baked solutions that do not solve the problem
+              in a reusable way. A reusable Service Locator must treat code as data, especially if you want additional
+              features like lifetime management.
+          </p>
+          <p>
+              Another point: take for example the <a href="https://msdn.microsoft.com/en-us/library/system.web.security.membershipprovider(v=vs.110).aspx">MembershipProvider</a>
+              class - this polymorphic abstraction is truly a violation of the Interface Segregation Principle because
+              it offers way too many members that a client probably won't need. But notice that each of these members has a different
+              meaning, which is not the case with the Create methods of the Service Locator. The generic Create method is just
+              another abstraction over the non-generic version to simplify the access to the Service Locator.
+          </p>
+          <p>
+              Long story short: Service Locator is a Metaprogramming API, the SOLID principles target Object-Oriented APIs,
+              thus the latter shouldn't be used to assess the former. There's is no real way to hide the fact that
+              clients need to be aware that they are calling a Metaprogramming API if they directly reference a 
+              Service Locator (which shouldn't be done in core logic).
+          </p>
+      </div>
+      <div class="comment-date">2016-01-08 09:40 UTC</div>
+  </div>
 </div>


### PR DESCRIPTION
I added another comment explaining why clients should be aware when they target an O-O or Metaprogramming API.