### PR TITLE
Comment on using POST to avoid hackability

### DIFF
--- a/_posts/2013-05-01-rest-lesson-learned-avoid-hackable-urls.html
+++ b/_posts/2013-05-01-rest-lesson-learned-avoid-hackable-urls.html
@@ -434,4 +434,23 @@ Location: http://example.com/0D25692DE79B4AF9A73F128554A9119E</pre>
 		</div>
 		<div class="comment-date">2016-03-10 07:34 UTC</div>
 	</div>
+
+  	<div class="comment">
+		<div class="comment-author"><a href="http://ruben.verborgh.org">Ruben Verborgh</a></div>
+		<div class="comment-content">
+			<p>
+        One can always avoid hackable URLs with trickery, but would you say that leads to a cleaner solution? I agree that search is “one of the clearest cases for URI templates”, so why bother putting in an unneeded <code>POST</code> request just to avoid hackable URIs? I fail to see why this would be a better REST design, given that you loose the beneficial properties of the uniform interface constraints by overloading the <code>POST</code> method for what is essentially a read-only operation. The trade-off here is entirely non-technical: you trade the performance of the interface for the aesthetics of its URLs.
+			</p>
+			<p>
+        Here's how a website would do it: it would have an HTML form for a <code>GET</code> request, which would naturally lead to a hackable URL. Because that's how HTML forms work: like URI templates, they result in hackable URLs. It's unavoidable. Hackable URLs are a direct consequence of common hypermedia controls, which are a necessity to realize the hypermedia constraint. You can swim against the current and make more difficult hypermedia controls, but to whose benefit? It's much easier to just accept that hackability is a side-effect of HTML forms and URI templates.
+			</p>
+			<p>
+        Therefore, your thesis that one should avoid hackable URIs breaks down at this point. APIs with non-hackable URIs are inherently incompatible with URI templates—and why throw away this excellent means of affordance? After all, the most straightforward way to realize search functionality is with an in-band URI template. And URI templates lead to hackable URIs. Hence, hackable URIs occur in REST APIs. You can work around this, but it's quite artificial to do so. In essence, you're using the <code>POST</code> request to obfuscate the URI; having such a translation step for purely aesthetic motives complicates the API and sacrifices caching for no good reason. Hackable URIs are definitely the lesser evil of the two.
+			</p>
+			<p>
+        So, would you avoid hackable URIs at any cost? Or can you agree that they indeed have a place if we like to keep using the hypermedia controls that have been standardized?
+			</p>
+		</div>
+		<div class="comment-date">2016-03-10 23:50 UTC</div>
+	</div>
 </div>


### PR DESCRIPTION
I argue that hackable URLs should not be avoided at any cost, especially not if the workaround makes the API more complex.