### PR TITLE
Added Result union type,

### DIFF
--- a/_posts/2016-09-26-decoupling-decisions-from-effects.html
+++ b/_posts/2016-09-26-decoupling-decisions-from-effects.html
@@ -155,7 +155,12 @@ tags: [Unit Testing, Software Design, F#]
 		The F# core library doesn't (<a href="https://github.com/fsharp/FSharpLangDesign/blob/master/RFCs/FS-1004-result-type.md">yet</a>) come with an implementation of the Either monad, but it's easy to add. In this example, I'm using code from <a href="https://fsharpforfunandprofit.com">Scott Wlaschin's</a> <a href="https://fsharpforfunandprofit.com/posts/recipe-part2">railway-oriented programming</a>, although slightly modified, and including only the most essential building blocks for the example:
 	</p>
 	<p>
-		<pre style="font-family:Consolas;font-size:13;color:black;"><span style="color:blue;">module</span>&nbsp;<span style="color:teal;">Result</span>&nbsp;=
+		<pre style="font-family:Consolas;font-size:13;color:black;">
+<span style="color:blue;">type</span>&nbsp;<span style="color:teal;">Result<'TSuccess, 'TFailure></span>&nbsp;=
+    | Success <span style="color:blue;">of</span> 'TSuccess
+    | Failure <span style="color:blue;">of</span> 'TFailure
+		
+<span style="color:blue;">module</span>&nbsp;<span style="color:teal;">Result</span>&nbsp;=
 &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:green;">//&nbsp;(&#39;a&nbsp;-&gt;&nbsp;Result&lt;&#39;b,&nbsp;&#39;c&gt;)&nbsp;-&gt;&nbsp;Result&lt;&#39;a,&nbsp;&#39;c&gt;&nbsp;-&gt;&nbsp;Result&lt;&#39;b,&nbsp;&#39;c&gt;</span>
 &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">let</span>&nbsp;<span style="color:navy;">bind</span>&nbsp;<span style="color:navy;">f</span>&nbsp;=&nbsp;<span style="color:blue;">function</span>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|&nbsp;<span style="color:navy;">Success</span>&nbsp;succ&nbsp;<span style="color:blue;">-&gt;</span>&nbsp;<span style="color:navy;">f</span>&nbsp;succ


### PR DESCRIPTION
so that the `Result` module compiles.

Hopefully, this makes it easier for readers to just copy and paste, and compile the source code using their favorite code editor or IDE.