### PR TITLE
typo "applicably" should be "applicable"

### DIFF
--- a/_posts/2017-08-28-the-builder-functor.html
+++ b/_posts/2017-08-28-the-builder-functor.html
@@ -120,7 +120,7 @@ tags: [Unit Testing, Haskell, F#, Functional Programming]
 		A type like <code>Builder&lt;T&gt;</code> with a suitable <code>Select</code> method is a <em>functor</em>. This is a term from category theory, but I'll try to avoid turning this article into a category theory lecture. Likewise, I'm not going to talk specifically about monads here, although it's a closely related topic. A functor is a mapping between categories; it maps an object from one category into an object of another category.
 	</p>
 	<p>
-		Although I've never seen Microsoft explicitly acknowledge the connection to functors and monads, it's clear that it's there. One of the principal designers of LINQ was <a href="https://en.wikipedia.org/wiki/Erik_Meijer_(computer_scientist)">Erik Meijer</a>, who definitely knows his way around category theory and functional programming. A functor is a simple, but widely applicably abstraction.
+		Although I've never seen Microsoft explicitly acknowledge the connection to functors and monads, it's clear that it's there. One of the principal designers of LINQ was <a href="https://en.wikipedia.org/wiki/Erik_Meijer_(computer_scientist)">Erik Meijer</a>, who definitely knows his way around category theory and functional programming. A functor is a simple, but widely applicable abstraction.
 	</p>
 	<p>
 		In order to be a functor, a type must have an associated mapping. In C#'s query syntax, this is a method named <code>Select</code>, but more often it's called <code>map</code>.


### PR DESCRIPTION
"A functor is a simple, but widely applicably abstraction." should be "A functor is a simple, but widely applicable abstraction."