### PR TITLE
Add missing binary operation from example monoid

### DIFF
--- a/_posts/2017-11-13-endomorphism-monoid.html
+++ b/_posts/2017-11-13-endomorphism-monoid.html
@@ -11,7 +11,7 @@ tags: [Software Design]
 		<em>A method that returns the same type of output as its input forms a monoid. An article for object-oriented programmers.</em>
 	</p>
 	<p>
-		This article is part of a <a href="http://blog.ploeh.dk/2017/10/06/monoids">series about monoids</a>. In short, a <em>monoid</em> is an associative binary operation with a neutral element (also known as <em>identity</em>). Methods that return the same type of value as their input form monoids. The formal term for such an operation is an <a href="https://en.wikipedia.org/wiki/Endomorphism">endomorphism</a>.
+		This article is part of a <a href="http://blog.ploeh.dk/2017/10/06/monoids">series about monoids</a>. In short, a <em>monoid</em> is an associative binary operation with a neutral element (also known as <em>identity</em>). Methods that return the same type of value as their input form monoids over composition. The formal term for such an operation is an <a href="https://en.wikipedia.org/wiki/Endomorphism">endomorphism</a>.
 	</p>
 	<p>
 		<strong>Scheduling example</strong>


### PR DESCRIPTION
I puzzled for a while over the original sentence, "Methods that return the same type of value as their input form monoids" because my initial interpretation was that you were considering methods with two arguments and that those would constitute the monoid's binary operator. Since monoids require two things - a set and a binary operation over that set - and the sentence in question talks about two things - values of a particular type, and methods that operate on them - that seemed like the natural way to interpret the sentence.

However, obviously not all such (methods + value sets) form monoids. So I eventually guessed that what you actually meant is that the methods are the monoid's set, and that you've left it as an exercise for the reader to work out what operator(s) you had in mind. Possibly you meant to set this very challenge in the opening paragraph, but I think it's easier to follow if specify the binary operator explicitly.