### PR TITLE
Update 2019-01-15-unit-isomorphisms.html

### DIFF
--- a/_posts/2019-01-15-unit-isomorphisms.html
+++ b/_posts/2019-01-15-unit-isomorphisms.html
@@ -127,7 +127,7 @@ val it : unit = ()</pre>
 ()</pre>
 	</p>
 	<p>
-		In fact, the above (rhetoric) question is imprecise, since there aren't <em>two</em> unit values. There's only one, but used twice.
+		In fact, the above (rhetorical) question is imprecise, since there aren't <em>two</em> unit values. There's only one, but used twice.
 	</p>
 	<p>
 		Since only a single <em>unit</em> value exists, any binary operation is automatically associative, because, after all, it can only return <em>unit</em>. Likewise, <em>unit</em> is the identity (<code>mempty</code>) for the operation, because it doesn't change the output. Thus, the monoid laws hold, and <em>unit</em> forms a monoid.


### PR DESCRIPTION
Fixed typo. I think rhetorical is more correct in this case.
The line ending change was introduced by the editor on GitHub. Feel free to ignore that.