### PR TITLE
improved grammar

### DIFF
--- a/_posts/2016-02-10-types--properties--software.html
+++ b/_posts/2016-02-10-types--properties--software.html
@@ -38,7 +38,7 @@ image_alt: "A spectrum of languages, from most dynamic on the left, to most stat
 		<img src="/content/binary/type-spectrum.png" alt="A spectrum of languages, from most dynamic on the left, to most static on the right.">
 	</p>
 	<p>
-		To the left, we have dynamically typed languages like JavaScript and Ruby. Python <em>can</em> be compiled, and Clojure <em>is</em> compiled, so we can think of them as being a little closer to the middle. Purists would want to point out that whether or not a language is compiled, and how statically typed it is, is two independent concerns, but the point of this spectrum is to illustrate the degree of confidence the type system gives you.
+		To the left, we have dynamically typed languages like JavaScript and Ruby. Python <em>can</em> be compiled, and Clojure <em>is</em> compiled, so we can think of them as being a little closer to the middle. Purists would want to point out that whether or not a language is compiled and how statically typed it is are two independent concerns, but the point of this spectrum is to illustrate the degree of confidence the type system gives you.
 	</p>
 	<p>
 		Java and C# are statically typed, compiled languages, but a lot of things can still go wrong at run-time. Just consider all the null pointer exceptions you've encountered over the years.


### PR DESCRIPTION
Removed two (spliced) commas and changed "is" to "are" to have the verb match the multiplicity of the subject.