### PR TITLE
fix formatting of comment about overflow

### DIFF
--- a/_posts/2020-02-03-non-exceptional-averages.html
+++ b/_posts/2020-02-03-non-exceptional-averages.html
@@ -255,20 +255,20 @@ tags: [Software Design]
 			<p>
                 Great post. I too prefer to avoid exceptions by strengthening preconditions using types.
 			</p>
-            <blockquote>
-                Since <code>tss</code> infinitely repeats <code>ts</code>, the <code>Average</code> method call (theoretically) loops forever; in fact it quickly overflows because it keeps adding <code>TimeSpan</code> values together.
-            </blockquote>
+            <blockquote>
+                Since <code>tss</code> infinitely repeats <code>ts</code>, the <code>Average</code> method call (theoretically) loops forever; in fact it quickly overflows because it keeps adding <code>TimeSpan</code> values together.
+            </blockquote>
 			<p>
-				I am not sure what you mean here.  My best guess is that you are saying that this code would execute forever except that it will overflow, which will halt the execution.  However, I think the situation is ambiguous.  This code is impure because, as the <a href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/checked-and-unchecked">Checked and Unchecked documentation</a> says, its behavior depends on whether or not the <code>-checked</code> compiler option is given.  This dependency on the compiler option can be removed by wrapping this code in a <a href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/checked">checked</a> or <a href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/unchecked">unchecked</a> block, which would either result in a thrown exception or an infinite loop respectively.
+                I am not sure what you mean here.  My best guess is that you are saying that this code would execute forever except that it will overflow, which will halt the execution.  However, I think the situation is ambiguous.  This code is impure because, as the <a href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/checked-and-unchecked">Checked and Unchecked documentation</a> says, its behavior depends on whether or not the <code>-checked</code> compiler option is given.  This dependency on the compiler option can be removed by wrapping this code in a <a href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/checked">checked</a> or <a href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/unchecked">unchecked</a> block, which would either result in a thrown exception or an infinite loop respectively.
 			</p>
-            <blockquote>
-                This gets the job done in most situations, but it has two error modes. It doesn't work if <code>timeSpans</code> is empty, and it doesn't work if it's infinite.
-            </blockquote>
-            <p>
-                There is a third error mode, and it exists in every implementation you gave.  The issue of overflow is not restricted to the case of infinitely many <code>TimeSpan</code>s.  It only takes two.  I know of or remember this bug as <a href="https://thebittheories.com/the-curious-case-of-binary-search-the-famous-bug-that-remained-undetected-for-20-years-973e89fc212">"the last binary search bug"</a>.  That article shows how to correctly compute the average of two integers without overflowing.  A correct implementation for computing the average of more than two integers is to map each element to a mixed fraction with the count as the divisor and then appropriately aggregate those values.  The implementation given in <a href="https://www.quora.com/How-can-I-compute-the-average-of-a-large-array-of-integers-without-running-into-overflow/answer/Mark-Gordon-6">this Quora answer</a> seems correct to me.
-            </p>
-            <p>
-                I know all this is unrelated to the topic of your post, but I also know how much you prefer to use examples that avoid this kind of accidental complexity.  Me too!  However, I still like your example and can't think of a better one at the moment.
+            <blockquote>
+                This gets the job done in most situations, but it has two error modes. It doesn't work if <code>timeSpans</code> is empty, and it doesn't work if it's infinite.
+            </blockquote>
+            <p>
+                There is a third error mode, and it exists in every implementation you gave.  The issue of overflow is not restricted to the case of infinitely many <code>TimeSpan</code>s.  It only takes two.  I know of or remember this bug as <a href="https://thebittheories.com/the-curious-case-of-binary-search-the-famous-bug-that-remained-undetected-for-20-years-973e89fc212">"the last binary search bug"</a>.  That article shows how to correctly compute the average of two integers without overflowing.  A correct implementation for computing the average of more than two integers is to map each element to a mixed fraction with the count as the divisor and then appropriately aggregate those values.  The implementation given in <a href="https://www.quora.com/How-can-I-compute-the-average-of-a-large-array-of-integers-without-running-into-overflow/answer/Mark-Gordon-6">this Quora answer</a> seems correct to me.
+            </p>
+            <p>
+                I know all this is unrelated to the topic of your post, but I also know how much you prefer to use examples that avoid this kind of accidental complexity.  Me too!  However, I still like your example and can't think of a better one at the moment.
             </p>
 		</div>
 		<div class="comment-date">2020-02-05 14:13 UTC</div>


### PR DESCRIPTION
Thanks for fixing my 12-hour for 24-hour typo.  Here is my attempt to remove the extra indentation in my comment.  If you want, feel free to make additional modifications if I still didn't get the formatting to look good.