### PR TITLE
Add Elm as an example functional language

### DIFF
--- a/_posts/2020-02-24-discerning-and-maintaining-purity.html
+++ b/_posts/2020-02-24-discerning-and-maintaining-purity.html
@@ -184,7 +184,8 @@ tags: [Functional Programming, Unit Testing, Architecture]
 		Language support <a href="#5413987a6af14316aee1b1de82aee73d" title="permalink">#</a>
 	</h3>
 	<p>
-		While no mainstream languages distinguish between pure functions and impure actions, there are languages that do. The most famous of these is <a href="https://www.haskell.org">Haskell</a>, but other examples include <a href="http://www.purescript.org">PureScript</a> and <a href="https://www.idris-lang.org">Idris</a>.
+		While no mainstream languages distinguish between pure functions and impure actions, there are languages that do. The most famous of these is <a href="https://www.
+			.org">Haskell</a>, but other examples include <a href="https://elm-lang.org/">Elm</a>, <a href="http://www.purescript.org">PureScript</a> and <a href="https://www.idris-lang.org">Idris</a>.
 	</p>
 	<p>
 		I find Haskell useful for exactly that reason. The compiler enforces the functional interaction law. You can't call impure actions from pure functions. Thus, you wouldn't be able to make a change to a function like <code>Validate</code> without changing its type. That would break most consuming code, which is a good thing.


### PR DESCRIPTION
Hi Mark

Opening Prs is the way to make comments, but I thought I might as well just propose the actual change instead.

I believe that one of your aims is to promote staticcally strongly typed functional languages, and I believe that Elm is probably the best way to do this.

Elm is targeted at front end development, and makes it easy to create websites, which is what most beginners are trying to do. The language has a strong focus on simplicity and a single recommended way of doing things, which is a refreshing change, especially in the front end world. It sits very well in it's target niche, and the runtime essentially provides an impure abstract syntax tree interpreter, leaving all your code 100% pure / functional. There is also a strong and vibrant community, which is both innovative and supportive to newcomers. It doesn't have all the features of haskell, which obviously has some good points and some bad points

Thanks

Cedd