### PR TITLE
fixed obverse for reverse typo

### DIFF
--- a/_posts/2020-03-02-impureim-sandwich.html
+++ b/_posts/2020-03-02-impureim-sandwich.html
@@ -23,7 +23,7 @@ image_alt: "A box with a thin red slice on top, a thick green middle, and a thin
 		In <a href="/2018/11/19/functional-architecture-a-definition">a functional architecture</a> <a href="https://en.wikipedia.org/wiki/Pure_function">pure functions</a> can't call impure actions. On the other hand, as <a href="https://en.wikipedia.org/wiki/Simon_Peyton_Jones">Simon Peyton Jones</a> observed in a lecture, <em>observing the result of pure computation is a side-effect</em>. In practical terms, <em>executing</em> a pure function is also impure, because it happens non-deterministically. Thus, even for a piece of software written in a functional style, the entry point must be impure.
 	</p>
 	<p>
-		While pure functions can't call impure actions, there's no rule to prevent the obverse. Impure actions <em>can</em> call pure functions.
+		While pure functions can't call impure actions, there's no rule to prevent the reverse. Impure actions <em>can</em> call pure functions.
 	</p>
 	<p>
 		Therefore, the best we can ever hope to achieve is an impure entry point that calls pure code and impurely reports the result from the pure function.


### PR DESCRIPTION
Replaced "obverse" with "reverse".  I think this is what you meant.