### PR TITLE
add comment to "The Maybe functor" post

### DIFF
--- a/_posts/2018-03-26-the-maybe-functor.html
+++ b/_posts/2018-03-26-the-maybe-functor.html
@@ -315,3 +315,22 @@ dest&nbsp;<span style="color:#666666;">=</span>&nbsp;show&nbsp;<span style="colo
 		<strong>Next:</strong> <a href="/2019/01/14/an-either-functor">An Either functor</a>.
 	</p>
 </div>
+
+<div id="comments">
+	<hr>
+	<h2 id="comments-header">
+		Comments
+	</h2>
+	<div class="comment" id="9192932dd15943228021ca6fcba20525">
+		<div class="comment-author"><a href="https://github.com/bert2">Robert Hofmann</a></div>
+		<div class="comment-content">
+			<p>
+				I think it's interesting to note that since C# 8.0 we don't require an extra generic type like <code>Maybe&lt;T&gt;</code> anymore in order to implement the maybe functor. Because C# 8.0 added nullable reference types, everything can be nullable now. By adding the right extension methods we can make <code>T?</code> a maybe functor and use its beautifully succinct syntax.
+			</p>
+			<p>
+				Due to the C#'s awkward dichotomy between value and reference types this involves some busy work, so I created a <a href="https://github.com/bert2/Nullable.Extensions">small nuget package</a> for interested parties.
+			</p>
+		</div>
+		<div class="comment-date">2020-03-28 08:25 UTC</div>
+	</div>
+</div> 


### PR DESCRIPTION
> I think it's interesting to note that since C# 8.0 we don't require an extra generic type like `Maybe<T>` anymore in order to implement the maybe functor. Because C# 8.0 added nullable reference types, everything can be nullable now. By adding the right extension methods we can make `T?` a maybe functor and use its beautifully succinct syntax.
>
> Due to the C#'s awkward dichotomy between value and reference types this involves some busy work, so I created a [small nuget package](https://github.com/bert2/Nullable.Extensions) for interested parties.