### PR TITLE
Update 2020-04-27-an-f-implementation-of-the-maitre-d-kata.html

### DIFF
--- a/_posts/2020-04-27-an-f-implementation-of-the-maitre-d-kata.html
+++ b/_posts/2020-04-27-an-f-implementation-of-the-maitre-d-kata.html
@@ -1041,7 +1041,7 @@ val it : seq&lt;int&gt; = seq []</pre>
 			<p>
 				You could leverage library functions and avoid mutability like so:
 				<pre><span style="color:green;">//&nbsp;(&#39;a&nbsp;-&gt;&nbsp;bool)&nbsp;-&gt;&nbsp;seq&lt;&#39;a&gt;&nbsp;-&gt;&nbsp;seq&lt;&#39;a&gt;</span>
-<span style="color:blue;">let</span>&nbsp;deleteFirstBy&nbsp;pred&nbsp;(xs&nbsp;:&nbsp;_&nbsp;seq)&nbsp;=&nbsp;seq&nbsp;{
+<span style="color:blue;">let</span>&nbsp;deleteFirstBy&nbsp;pred&nbsp;(xs&nbsp;:&nbsp;_&nbsp;seq)&nbsp;=
 &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">match</span>&nbsp;Seq.tryFindIndex pred xs&nbsp;<span style="color:blue;">with</span>
 &nbsp;&nbsp;&nbsp;&nbsp;|&nbsp;None&nbsp;<span style="color:blue;">-></span>&nbsp;xs
 &nbsp;&nbsp;&nbsp;&nbsp;|&nbsp;Some&nbsp;n&nbsp;<span style="color:blue;">-></span>&nbsp;Seq.concat&nbsp;(Seq.take&nbsp;(n-1)&nbsp;xs)&nbsp;(Seq.skip&nbsp;n&nbsp;xs)</pre>


### PR DESCRIPTION
Removed leftover " seq {" in alternate implementation.