### PR TITLE
Fix typo

### DIFF
--- a/_posts/2020-07-06-referential-transparency-of-io.html
+++ b/_posts/2020-07-06-referential-transparency-of-io.html
@@ -157,7 +157,7 @@ image_alt: "Diagram showing that the parallel-universe framework executes the IO
 		<img src="/content/binary/parallel-universe-fx-calling-unsafeperformio.png" alt="Diagram showing that the parrallel-universe framework executes the IO value after Main returns.">
 	</p>
 	<p>
-		The framework supplies command-line arguments to the <code>Main</code> method. Once the method returns an <code>IO&lt;Unit&gt;</code> object, the framework executes it with a special method that only the framework can invoke. Any other <code>IO</code> values that may have been created (e.g. the above <code>Console.WriteLine</code>) never gets executed, because they're not include in the return value.
+		The framework supplies command-line arguments to the <code>Main</code> method. Once the method returns an <code>IO&lt;Unit&gt;</code> object, the framework executes it with a special method that only the framework can invoke. Any other <code>IO</code> values that may have been created (e.g. the above <code>Console.WriteLine</code>) never gets executed, because they're not included in the return value.
 	</p>
 	<h3 id="d5fe0e97d9ea4442b3b4fb13ad28aab6">
 		Conclusion <a href="#d5fe0e97d9ea4442b3b4fb13ad28aab6" title="permalink">#</a>


### PR DESCRIPTION
Fix typo in the post "Referencial transparency of IO"