### PR TITLE
Referential transparency of IO: You mean discard?

### DIFF
--- a/_posts/2020-07-06-referential-transparency-of-io.html
+++ b/_posts/2020-07-06-referential-transparency-of-io.html
@@ -241,4 +241,40 @@ image_alt: "Diagram showing that the parallel-universe framework executes the IO
 		</div>
 		<div class="comment-date">2020-07-06 19:35 UTC</div>
 	</div>
+
+	<div class="comment" id="247a2c05d83a485a99225057829afa71">
+		<div class="comment-author"><a href="https://www.raboof.com/">Atif Aziz</a></div>
+		<div class="comment-content">
+			<blockquote>
+				You can get around the issue using the language's wildcard pattern.
+				This tells the compiler that you're actively ignoring the result of the action.
+			</blockquote>
+			<p>
+				You made a standard variable declaration and I believe you meant
+				to use a <a href="https://docs.microsoft.com/en-us/dotnet/csharp/discards#a-standalone-discard">stand-alone discard</a>
+				rather than a wildcard pattern? Like below?
+			</p>
+			<p>
+<pre><span style="color:blue;">public</span>&nbsp;<span style="color:blue;">static</span>&nbsp;<span style="color:blue;">string</span>&nbsp;Greet(<span style="color:#2b91af;">DateTime</span>&nbsp;now,&nbsp;<span style="color:blue;">string</span>&nbsp;name)
+{
+&nbsp;&nbsp;&nbsp;&nbsp;_&nbsp;=&nbsp;<span style="color:#2b91af;">Console</span>.WriteLine(<span style="color:#a31515;">&quot;Side&nbsp;effect!&quot;</span>);
+	
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">var</span>&nbsp;greeting&nbsp;=&nbsp;<span style="color:#a31515;">&quot;Hello&quot;</span>;
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">if</span>&nbsp;(IsMorning(now))
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;greeting&nbsp;=&nbsp;<span style="color:#a31515;">&quot;Good&nbsp;morning&quot;</span>;
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">if</span>&nbsp;(IsAfternoon(now))
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;greeting&nbsp;=&nbsp;<span style="color:#a31515;">&quot;Good&nbsp;afternoon&quot;</span>;
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">if</span>&nbsp;(IsEvening(now))
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;greeting&nbsp;=&nbsp;<span style="color:#a31515;">&quot;Good&nbsp;evening&quot;</span>;
+	
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">if</span>&nbsp;(<span style="color:blue;">string</span>.IsNullOrWhiteSpace(name))
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">return</span>&nbsp;<span style="color:#a31515;">$&quot;</span>{greeting}<span style="color:#a31515;">.&quot;</span>;
+	
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">return</span>&nbsp;<span style="color:#a31515;">$&quot;</span>{greeting}<span style="color:#a31515;">,&nbsp;</span>{name.Trim()}<span style="color:#a31515;">.&quot;</span>;
+}</pre>
+			</p>
+		</div>
+		<div class="comment-date">2020-07-09 08:18 UTC</div>
+	</div>
 </div>
+


### PR DESCRIPTION
### Comment

> You can get around the issue using the language's wildcard pattern. This tells the compiler that you're actively ignoring the result of the action.

You made a standard variable declaration and I believe you meant to use a [stand-alone discard] rather than a wildcard pattern? Like below?

  [stand-alone discard]: https://docs.microsoft.com/en-us/dotnet/csharp/discards#a-standalone-discard

```c#
public static string Greet(DateTime now, string name)
{
    _ = Console.WriteLine("Side effect!");
 
    var greeting = "Hello";
    if (IsMorning(now))
        greeting = "Good morning";
    if (IsAfternoon(now))
        greeting = "Good afternoon";
    if (IsEvening(now))
        greeting = "Good evening";
 
    if (string.IsNullOrWhiteSpace(name))
        return $"{greeting}.";
 
    return $"{greeting}, {name.Trim()}.";
}
```
