### PR TITLE
fixed typo by replacing "were" with "was"

### DIFF
--- a/_posts/2016-04-11-async-as-surrogate-io.html
+++ b/_posts/2016-04-11-async-as-surrogate-io.html
@@ -43,7 +43,7 @@ tags: [F#, ASP.NET Web API, Haskell]
 		Async I/O <a href="#c397291ccee4424c885f301122f96caa" title="permalink">#</a>
 	</h3>
 	<p>
-		In <a href="/2016/03/18/functional-architecture-is-ports-and-adapters">the previous Haskell example</a>, communication with the database were implemented by functions returning <code>IO</code>:		
+		In <a href="/2016/03/18/functional-architecture-is-ports-and-adapters">the previous Haskell example</a>, communication with the database was implemented by functions returning <code>IO</code>:		
 	</p>
 	<p>
 		<pre>getReservedSeatsFromDB :: ConnectionString -> ZonedTime -> IO Int


### PR DESCRIPTION
Instead of replacing "were" with "was", another fix is to replace "communication" with "communications".