### PR TITLE
Fix typo order to orders

### DIFF
--- a/_posts/2013-05-01-rest-lesson-learned-avoid-hackable-urls.html
+++ b/_posts/2013-05-01-rest-lesson-learned-avoid-hackable-urls.html
@@ -49,7 +49,7 @@ image: "/content/binary/great-divide-between-richardson-level-2-and-3.png"
 		One of the main attractions of building a level 3 RESTful API is that it's easier to evolve. Exactly because URL templates are <em>not</em> part of the contract, you can decide to change the URL structure when evolving your API.
 	</p>
 	<p>
-		Imagine that the first version of your API has an (internal) URL template like <code>/orders/{customerId}</code>, so that the example URL <code>http://foo.ploeh.dk/orders/1234</code> is the address of the order history for customer <em>1234</em>. However, in version 2 of your API, you realize that this way of thinking is still too RPC-like, and you'd rather prefer <code>/customers/{customerId}/order</code>, e.g. <code>http://foo.ploeh.dk/customers/1234/orders</code>.
+		Imagine that the first version of your API has an (internal) URL template like <code>/orders/{customerId}</code>, so that the example URL <code>http://foo.ploeh.dk/orders/1234</code> is the address of the order history for customer <em>1234</em>. However, in version 2 of your API, you realize that this way of thinking is still too RPC-like, and you'd rather prefer <code>/customers/{customerId}/orders</code>, e.g. <code>http://foo.ploeh.dk/customers/1234/orders</code>.
 	</p>
 	<p>
 		With a level 3 RESTful API, you can change your internal URL templates, and as long as you keep providing links, clients following links will not notice the difference. However, if clients are 'hacking' your URLs, their applications may stop working if you change URL templates.


### PR DESCRIPTION
This PR replaces one occurrence of "order" with "orders".  I think "orders" was intended, but maybe I misunderstood something.