### PR TITLE
Specified that a monoid is a set + an operation

### DIFF
--- a/_posts/2017-10-06-monoids.html
+++ b/_posts/2017-10-06-monoids.html
@@ -150,7 +150,7 @@ image_alt: "Monoids are a subset of semigroups."
 		Summary <a href="#3b10b1afa0d0469392bf89fec90ea371" title="permalink">#</a>
 	</h3>
 	<p>
-		A monoid (not to be confused with a monad) is a binary operation that satisfies the two monoid laws: that the operation is associative, and that an identity element exists. Addition and multiplication are prime examples, but several others exist.
+		A monoid (not to be confused with a monad) is a set (a type) equipped with a binary operation that satisfies the two monoid laws: that the operation is associative, and that an identity element exists. Addition and multiplication are prime examples, but several others exist.
 	</p>
 	<p>
 		(By the way, the identity element for multiplication is <em>one</em> (<em>1</em>), the <em>all</em> monoid is boolean <em>and</em>, and the <em>any</em> monoid is boolean <em>or</em>.)


### PR DESCRIPTION
This PR contains a small change, aimed to provide a slightly more precise definition of a monoid.

In the beginning of your post series you mention that 

> a monoid is a combination of a data type (or set) and an operation.

From there on, though, it seems that you conflate the two components and you only refer to monoids other algebraic structures just as "operations":

> A monoid (not to be confused with a monad) is a binary operation
> Semigroups form a superset of monoids. They are associative binary operations.

That's not quite right. Semigroups are not functions, and they are possibly better described as "algebraic structures consisting of a set together with an associative binary operation".


I think in the narrative this could be a convenient simplification, especially since in FP we always deal with the same category of types.
Sometimes, though, that's a bit misleading. For example, in 

> a monoid is an associative binary operation with a neutral element (also known as identity). 

the reader may wonder how an operation (and not a set) can have a neutral element.

While it's nice only talking of operations in the narrative, I would suggest sticking to more precise descriptions when providing the definition of a concept.

This PR just changes the part of the post where the definition of a monoid is given, repeating that it's actually a set + an operation.