### PR TITLE
Comment about using the new [FromServices] for DI

### DIFF
--- a/_posts/2017-01-27-dependency-injection-is-passing-an-argument.html
+++ b/_posts/2017-01-27-dependency-injection-is-passing-an-argument.html
@@ -141,3 +141,22 @@ tags: [Software Design, Dependency Injection]
 		<strong>Next:</strong> <a href="/2017/01/30/partial-application-is-dependency-injection">Partial application is dependency injection</a>.
 	</p>
 </div>
+
+<div id="comments">
+	<hr>
+	<h2 id="comments-header">
+		Comments
+	</h2>
+	<div class="comment">
+		<div class="comment-author"><a href="https://github.com/julealgon">Juliano Leal Goncalves</a></div>
+		<div class="comment-content">
+			<p>
+				Hey Mark. You may want to update the article slightly to cover the use of the <code>[FromServices]</code> attribute, which allows you to inject any service into a controller action as method-level injection. The main article on it <a href="https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/dependency-injection?view=aspnetcore-5.0#action-injection-with-fromservices">is this one</a>.
+			</p>
+			<p>
+				I'm personally not a fan of using it, but it is an option that transforms standard injection into parameter-passing for controllers.
+			</p>
+		</div>
+		<div class="comment-date">2020-02-23 15:11 UTC</div>
+	</div>
+</div>


### PR DESCRIPTION
Adds a comment on `dependency-injection-is-passing-an-argument` in regards to using the `[FromServices]` attribute for injecting dependencies in controllers as method arguments.