### PR TITLE
Using new Task<T>s that are not started to enforce Method purity

### DIFF
--- a/_posts/2020-07-27-task-asynchronous-programming-as-an-io-surrogate.html
+++ b/_posts/2020-07-27-task-asynchronous-programming-as-an-io-surrogate.html
@@ -142,3 +142,24 @@ tags: [Functional Programming]
 		The compiler, on the other hand, doesn't help you when it comes to those impure actions that look pure. Neither does it protect you against asynchronous side effects. Diligence, code reviews, and programming discipline are still required if you want to separate pure functions from impure actions.
 	</p>
 </div>
+
+<div id="comments">
+	<hr>
+	<h2 id="comments-header">
+		Comments
+	</h2>
+	<div class="comment" id="c0b2e0bd500a4d5c8407c60bf11bff69">
+		<div class="comment-author"><a href="http://spoc-web.com">Matt Heuer</a></div>
+		<div class="comment-content">
+			<p>
+				This is a great idea. 
+				It seems like the only Problem with Tasks is that they are usually already started, 
+				either on the current or a Worker Thread. 
+				
+				What if the IO<T> Class would not return an IO&lt;T> but a Task&lt;IO&lt;TResult>>? 
+				Invoking the 
+			</p>
+		</div>
+		<div class="comment-date">2021-02-20 18:57 UTC</div>
+	</div>
+</div>

--- a/_posts/2020-07-27-task-asynchronous-programming-as-an-io-surrogate.html
+++ b/_posts/2020-07-27-task-asynchronous-programming-as-an-io-surrogate.html
@@ -156,10 +156,58 @@ tags: [Functional Programming]
 				It seems like the only Problem with Tasks is that they are usually already started, 
 				either on the current or a Worker Thread. 
 				
-				What if the IO<T> Class would not return an IO&lt;T> but a Task&lt;IO&lt;TResult>>? 
-				Invoking the 
+				If we return Tasks that are not started yet, then Side-Effects don't happen until we await them. 
+				And we have to await them to get their Result or use them in other Tasks.
+				
+				I experimented with a modified GetTime() Method returning a new Task that is not run yet:
+			</p>
+			<pre>
+	public static Task<DateTime> GetTime() => new Task<DateTime>(() => DateTime.Now);
+			</pre>
+			<p>
+				Using a SelectMany Method that ensures that Tasks have been run, 
+				the Time is not evaluated until the resulting Task is awaited 
+				or another SelectMany is built using the Task from the first SelectMany. 
+				The Time of one such Task is also evaluated only once. On repeating Calls the same Result is returned:
+			</p>
+			<pre>
+	public static async Task<TResult> SelectMany<T, TResult>(this Task<T> source
+		, Func<T, Task<TResult>> project) {
+		T t = await source.GetResultAsync();
+		Task<TResult>? ret = project(t);
+		return await ret.GetResultAsync();
+	}
+
+	/// <summary> Asynchronously runs the <paramref name="task"/> to Completion </summary>
+	/// <returns><see cref="Task{T}.Result"/></returns>
+	public static async Task<T> GetResultAsync<T>(this Task<T> task) {
+		switch (task.Status) {
+			case TaskStatus.Created: await Task.Run(task.RunSynchronously); return task.Result;
+			case TaskStatus.WaitingForActivation:
+			case TaskStatus.WaitingToRun:
+			case TaskStatus.Running:
+			case TaskStatus.WaitingForChildrenToComplete: return await task;
+			case TaskStatus.Canceled:
+			case TaskStatus.Faulted:
+			case TaskStatus.RanToCompletion: return task.Result; //let the Exceptions fly...
+			default: throw new ArgumentOutOfRangeException();
+		}
+	}
+			</pre>
+			<p>
+				Since I/O Operations with side-effects are usually asynchronous anyway, 
+				Tasks and I/O are a good match. <br/>
+				Consistenly not starting Tasks and using this SelectMany Method 
+				either ensures Method purity or enforces to return the Task. 
+				
+				To avoid ambiguity with started Tasks a Wrapper-IO-Class could be constructed, 
+				that always takes and creates unstarted Tasks. 
+				
+				Am I missing something or do you think this would not be worth the effort? 
+				Are there more idiomatic ways to start enforcing purity in C#, 
+				except e.g. using the [Pure] Attribute and StyleCop-Warnings for unused Return Values?
 			</p>
 		</div>
-		<div class="comment-date">2021-02-20 18:57 UTC</div>
+		<div class="comment-date">2021-02-27 22:25 UTC</div>
 	</div>
 </div>


### PR DESCRIPTION
Hi, your IO<T> C# Class was very instructive. 
I tried to close the gap you mentioned of Tasks already running and performing side-effects even when their result is ignored 
and found a working SelectMany Implementation that evaluates the Task lazily and only once. 

The idea is to consistently return Tasks that are NOT started and leave it to the Boundary Code to call await and thus trigger all Side Effects. 

I think it would be worth adopting such a practice, at least personally. What do you think?