### PR TITLE
added forward links to impureium sandwich article

### DIFF
--- a/_posts/2017-01-27-from-dependency-injection-to-dependency-rejection.html
+++ b/_posts/2017-01-27-from-dependency-injection-to-dependency-rejection.html
@@ -35,7 +35,7 @@ image_alt: "Bob: How do I do dependency injection in Scala? Other man: You don't
 		You can often make do with less, though.
 	</p>
 	<p>
-		In my experience, it's usually enough to refactor a unit to take only direct input and output, and then compose an impure/pure/impure 'sandwich'. You'll see an example later.
+		In my experience, it's usually enough to refactor a unit to take only direct input and output, and then compose an <a href="/2020/03/02/impureim-sandwich">impure/pure/impure 'sandwich'</a>. You'll see an example later.
 	</p>
 	<p>
 		This article series contains the following parts:

--- a/_posts/2017-02-02-dependency-rejection.html
+++ b/_posts/2017-02-02-dependency-rejection.html
@@ -170,7 +170,7 @@ tryAcceptComposition&nbsp;reservation&nbsp;<span style="color:#666666;">=</span>
 		This version of <code>tryAcceptComposition</code> compiles, and works as desired. The code exhibits a common pattern for Haskell: First, gather data from impure sources. Second, pass pure data to pure functions. Third, take the pure output from the pure functions, and do something impure with it.
 	</p>
 	<p>
-		It's like a sandwich, with the best parts in the middle, and some necessary stuff surrounding it.
+		It's like a <a href="/2020/03/02/impureim-sandwich">sandwich</a>, with the best parts in the middle, and some necessary stuff surrounding it.
 	</p>
 	<h3 id="2768ff7f9aa94e7f962ba706d2cf30e6">
 		Summary <a href="#2768ff7f9aa94e7f962ba706d2cf30e6" title="permalink">#</a>

--- a/_posts/2017-07-10-pure-interactions.html
+++ b/_posts/2017-07-10-pure-interactions.html
@@ -12,7 +12,7 @@ tags: [Software Design, Dependency Injection, Functional Programming, Article Se
 		<em>{{ page.description }}</em>
 	</p>
 	<p>
-		In a <a href="/2017/01/30/partial-application-is-dependency-injection">previous article</a>, you can read why Dependency Injection and (strict) functional programming are mutually exclusive. Dependency Injection makes everything impure, and if nothing is <a href="https://en.wikipedia.org/wiki/Pure_function">pure</a>, then it's hardly functional. In <a href="/2017/02/02/dependency-rejection">Dependency rejection</a>, you can see how you can often separate impure and pure code into an impure/pure/impure sandwich.
+		In a <a href="/2017/01/30/partial-application-is-dependency-injection">previous article</a>, you can read why Dependency Injection and (strict) functional programming are mutually exclusive. Dependency Injection makes everything impure, and if nothing is <a href="https://en.wikipedia.org/wiki/Pure_function">pure</a>, then it's hardly functional. In <a href="/2017/02/02/dependency-rejection">Dependency rejection</a>, you can see how you can often separate impure and pure code into an <a href="/2020/03/02/impureim-sandwich">impure/pure/impure sandwich</a>.
 	</p>
 	<h3 id="2d0ec1b9ac0c47e08cb94122c1822d6f">
 		Micro-operation-based architectures <a href="#2d0ec1b9ac0c47e08cb94122c1822d6f" title="permalink">#</a>

--- a/_posts/2017-07-11-hello-pure-command-line-interaction.html
+++ b/_posts/2017-07-11-hello-pure-command-line-interaction.html
@@ -12,7 +12,7 @@ tags: [Software Design, Dependency Injection, F#, Functional Programming]
 		<em>{{ page.description }}</em>
 	</p>
 	<p>
-		Dependency Injection is a <a href="http://amzn.to/12p90MG">well-described</a> concept in object-oriented programming, but as I've <a href="/2017/01/30/partial-application-is-dependency-injection">explained earlier</a>, its not functional, because it makes everything impure. In general, you should <a href="/2017/02/02/dependency-rejection">reject the notion of dependencies</a> by instead designing your application on the concept of an impure/pure/impure sandwich. This is possible more often than you'd think, but <a href="/2017/07/10/pure-interactions">there's still a large group of applications where this will not work</a>. If your application needs to interact with the impure world for an extended time, you need a way to model such interactions in a pure way.
+		Dependency Injection is a <a href="http://amzn.to/12p90MG">well-described</a> concept in object-oriented programming, but as I've <a href="/2017/01/30/partial-application-is-dependency-injection">explained earlier</a>, its not functional, because it makes everything impure. In general, you should <a href="/2017/02/02/dependency-rejection">reject the notion of dependencies</a> by instead designing your application on the concept of an <a href="/2020/03/02/impureim-sandwich">impure/pure/impure sandwich</a>. This is possible more often than you'd think, but <a href="/2017/07/10/pure-interactions">there's still a large group of applications where this will not work</a>. If your application needs to interact with the impure world for an extended time, you need a way to model such interactions in a pure way.
 	</p>
 	<p>
 		This article introduces a way to do that.

--- a/_posts/2019-08-26-functional-file-system.html
+++ b/_posts/2019-08-26-functional-file-system.html
@@ -98,7 +98,7 @@ image_alt: "Object-oriented and functional ways to abstractly model file systems
 		Functional picture archivist <a href="#6cddf0e7ca3549c49a87006bfba5d349" title="permalink">#</a>
 	</h3>
 	<p>
-		In functional programming, you'll have to <a href="/2017/02/02/dependency-rejection">reject the notion of dependencies</a>. Instead, you can often resort to the simple architecture I call an <em>impure-pure-impure sandwich</em>; here, specifically:
+		In functional programming, you'll have to <a href="/2017/02/02/dependency-rejection">reject the notion of dependencies</a>. Instead, you can often resort to the simple architecture I call an <a href="/2020/03/02/impureim-sandwich"><em>impure-pure-impure sandwich</em></a>; here, specifically:
 		<ol>
 			<li>Load data from disk (impure)</li>
 			<li>Transform the data (pure)</li>

--- a/_posts/2019-09-09-picture-archivist-in-haskell.html
+++ b/_posts/2019-09-09-picture-archivist-in-haskell.html
@@ -432,7 +432,7 @@ applyMoves&nbsp;=&nbsp;traverse_&nbsp;move
 		Composition <a href="#d336cf55dc9746c08cbed32041803173" title="permalink">#</a>
 	</h3>
 	<p>
-		You can now compose an <em>impure-pure-impure sandwich</em> from all the Lego pieces:
+		You can now compose an <a href="/2020/03/02/impureim-sandwich"><em>impure-pure-impure sandwich</em></a> from all the Lego pieces:
 	</p>
 	<p>
 		<pre><span style="color:#2b91af;">movePhotos</span>&nbsp;::&nbsp;<span style="color:#2b91af;">FilePath</span>&nbsp;<span style="color:blue;">-&gt;</span>&nbsp;<span style="color:#2b91af;">FilePath</span>&nbsp;<span style="color:blue;">-&gt;</span>&nbsp;<span style="color:#2b91af;">IO</span>&nbsp;()

--- a/_posts/2019-09-16-picture-archivist-in-f.html
+++ b/_posts/2019-09-16-picture-archivist-in-f.html
@@ -469,7 +469,7 @@ val it : Tree&lt;string,int&gt; option = Some (Node ("Foo",[Leaf 42; Leaf 2112])
 		Composition <a href="#f30093164b184bbf877f307fa4cf4c63" title="permalink">#</a>
 	</h3>
 	<p>
-		You can now compose an <em>impure-pure-impure sandwich</em> from all the Lego pieces:
+		You can now compose an <a href="/2020/03/02/impureim-sandwich"><em>impure-pure-impure sandwich</em></a> from all the Lego pieces:
 	</p>
 	<p>
 		<pre><span style="color:green;">//&nbsp;string&nbsp;-&gt;&nbsp;string&nbsp;-&gt;&nbsp;unit</span>

--- a/_posts/2019-12-02-refactoring-registration-flow-to-functional-architecture.html
+++ b/_posts/2019-12-02-refactoring-registration-flow-to-functional-architecture.html
@@ -21,7 +21,7 @@ image_alt: "A flowchart describing the workflow for completing a registration."
 		<a href="https://www.relativisticramblings.com">Christer van der Meeren</a> kindly <a href="/2017/02/02/dependency-rejection#ade3787e6e3c4e569854e2c2bd038e29">replied with a suggestion.</a>
 	</p>
 	<p>
-		The code in question relates to validation of user accounts. You can read the complete description in the linked comment, but I'll try to summarise it here. I'll then show a refactoring to a <a href="/2018/11/19/functional-architecture-a-definition">functional architecture</a> - specifically, to an impure/pure/impure sandwich.
+		The code in question relates to validation of user accounts. You can read the complete description in the linked comment, but I'll try to summarise it here. I'll then show a refactoring to a <a href="/2018/11/19/functional-architecture-a-definition">functional architecture</a> - specifically, to an <a href="/2020/03/02/impureim-sandwich">impure/pure/impure sandwich</a>.
 	</p>
 	<p>
 		The code is <a href="https://github.com/ploeh/RegistrationFlow">available on GitHub</a>.


### PR DESCRIPTION
Resolves #716

This PR adds forward links to the [impureium sandwich article](https://blog.ploeh.dk/2020/03/02/impureim-sandwich/) (i.e. links to that article from articles written before it).  I searched for `sandwich` and added the link at most once per article at the first "available" occurrence (i.e. not in the description or text that already contained a link).

Here are all the articles that include the world `sandwich` but I did not add a link...and the reason why.
1. [`2017-08-07-f-free-monad-recipe.html`](https://blog.ploeh.dk/2017/08/07/f-free-monad-recipe/) (2 hits): Both already link to [`2017/07/10/pure-interactions`](https://blog.ploeh.dk/2017/07/10/pure-interactions/)
2. [`2018-11-19-functional-architecture-a-definition.html` ](https://blog.ploeh.dk/2018/11/19/functional-architecture-a-definition/)(1 hit): Already links to [`2017/02/02/dependency-rejection`](https://blog.ploeh.dk/2017/02/02/dependency-rejection/)
3. `2019-02-11-asynchronous-injection.html` (2 hits): Both in comments.  One by a reader and one by you that already links to [`2017/02/02/dependency-rejection`](https://blog.ploeh.dk/2017/02/02/dependency-rejection/)

Note that this PR adds links from `2017/07/10/pure-interactions` and `2017/02/02/dependency-rejection` to the impureium sandwich article, so all three of those articles transitively link to the [impureium sandwich article.