### PR TITLE
Fix broken links pointing to MSDN blog

### DIFF
--- a/_posts/2009-01-28-Zero-FrictionTDD.html
+++ b/_posts/2009-01-28-Zero-FrictionTDD.html
@@ -21,7 +21,7 @@ description: "An article series about unit testing and test-driven development i
 		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/ignore-irrelevant-return-values">Ignore Irrelevant Return Values</a></li>
 		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/testmethod-code-snippet">testmethod Code Snippet</a></li>
 		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/3-is-many">3 Is Many</a></li>
-		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/why-use-areequal-t">Why Use AreEqual&lt;T&gt;?</a></li>
+		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/why-use-areequalt">Why Use AreEqual&lt;T&gt;?</a></li>
 		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/assert-messages-are-not-optional">Assert Messages Are Not Optional</a></li>
 		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/use-the-generate-method-stub-smart-tag-to-stay-in-the-zone">Use The Generate Method Stub Smart Tag To Stay In The Zone</a></li>
 		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/test-driven-properties">Test-Driven Properties</a></li>

--- a/_posts/2009-01-28-Zero-FrictionTDD.html
+++ b/_posts/2009-01-28-Zero-FrictionTDD.html
@@ -9,22 +9,22 @@ description: "An article series about unit testing and test-driven development i
 
 <div id="post">
 	<p>
-		In my original post on <a href="http://blogs.msdn.com/ploeh/archive/2008/11/13/zero-friction-tdd.aspx">Zero-Friction TDD</a>, I continually updated the list of posts in the series, so that there would always be a central 'table of contents' for this topic.
+		In my original post on <a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/zero-friction-tdd">Zero-Friction TDD</a>, I continually updated the list of posts in the series, so that there would always be a central 'table of contents' for this topic.
 	</p>
 	<p>
-		Since <a href="/2009/01/28/LivingInInterestingTimes">I'll lose the ability to keep editing any of my previous postings</a> on the old <a href="http://blogs.msdn.com/ploeh">ploeh blog</a>, the present post now contains the most updated list of Zero-Friction TDD articles:
+		Since <a href="/2009/01/28/LivingInInterestingTimes">I'll lose the ability to keep editing any of my previous postings</a> on the old <a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/">ploeh blog</a>, the present post now contains the most updated list of Zero-Friction TDD articles:
 	</p>
 	<ul>
-		<li><a href="http://blogs.msdn.com/ploeh/archive/2008/10/06/naming-sut-test-variables.aspx">Naming SUT Test Variables</a></li>
-		<li><a href="http://blogs.msdn.com/ploeh/archive/2008/11/14/naming-direct-output-variables.aspx">Naming Direct Output Variables</a></li>
-		<li><a href="http://blogs.msdn.com/ploeh/archive/2008/11/17/anonymous-variables.aspx">Anonymous Variables</a></li>
-		<li><a href="http://blogs.msdn.com/ploeh/archive/2008/11/21/ignore-irrelevant-return-values.aspx">Ignore Irrelevant Return Values</a></li>
-		<li><a href="http://blogs.msdn.com/ploeh/archive/2008/12/01/testmethod-code-snippet.aspx">testmethod Code Snippet</a></li>
-		<li><a href="http://blogs.msdn.com/ploeh/archive/2008/12/08/3-is-many.aspx">3 Is Many</a></li>
-		<li><a href="http://blogs.msdn.com/ploeh/archive/2008/12/11/why-use-areequal-t.aspx">Why Use AreEqual&lt;T&gt;?</a></li>
-		<li><a href="http://blogs.msdn.com/ploeh/archive/2008/12/17/assert-messages-are-not-optional.aspx">Assert Messages Are Not Optional</a></li>
-		<li><a href="http://blogs.msdn.com/ploeh/archive/2009/01/05/use-the-generate-method-stub-smart-tag-to-stay-in-the-zone.aspx">Use The Generate Method Stub Smart Tag To Stay In The Zone</a></li>
-		<li><a href="http://blogs.msdn.com/ploeh/archive/2009/01/12/test-driven-properties.aspx">Test-Driven Properties</a></li>
+		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/naming-sut-test-variables">Naming SUT Test Variables</a></li>
+		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/naming-direct-output-variables">Naming Direct Output Variables</a></li>
+		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/anonymous-variables">Anonymous Variables</a></li>
+		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/ignore-irrelevant-return-values">Ignore Irrelevant Return Values</a></li>
+		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/testmethod-code-snippet">testmethod Code Snippet</a></li>
+		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/3-is-many">3 Is Many</a></li>
+		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/why-use-areequal-t">Why Use AreEqual&lt;T&gt;?</a></li>
+		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/assert-messages-are-not-optional">Assert Messages Are Not Optional</a></li>
+		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/use-the-generate-method-stub-smart-tag-to-stay-in-the-zone">Use The Generate Method Stub Smart Tag To Stay In The Zone</a></li>
+		<li><a href="https://docs.microsoft.com/en-us/archive/blogs/ploeh/test-driven-properties">Test-Driven Properties</a></li>
 		<li><a href="/2009/02/13/SUTFactory">SUT Factory</a></li>
 		<li><a href="/2009/03/03/DerivedValuesEnsureExecutableSpecification">Derived Values Ensure Executable Specification</a></li>
 		<li><a href="/2009/03/05/ConstrainedNon-Determinism">Constrained Non-Determinism</a></li>


### PR DESCRIPTION
Microsoft must have moved domains from blogs.msdn.com to docs.microsoft.com. The link structure also changed and specific post links didn't forward correctly.