### PR TITLE
Fix typo in 2021-10-04-reader-as-a-contravariant-functor

### DIFF
--- a/_posts/2021-10-04-reader-as-a-contravariant-functor.html
+++ b/_posts/2021-10-04-reader-as-a-contravariant-functor.html
@@ -242,7 +242,7 @@ tags: [Software Design]
 &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:#8f08c4;">return</span>&nbsp;<span style="color:#1f377f;">candidate</span>&nbsp;=&gt;&nbsp;specification.IsSatisfiedBy(candidate);
 }
  
-<span style="color:blue;">public</span>&nbsp;<span style="color:blue;">static</span>&nbsp;Predicate&lt;T&gt;&nbsp;<span style="color:#74531f;">AsFunc</span>&lt;<span style="color:#2b91af;">T</span>&gt;(<span style="color:blue;">this</span>&nbsp;ISpecification&lt;T&gt;&nbsp;<span style="color:#1f377f;">specification</span>)
+<span style="color:blue;">public</span>&nbsp;<span style="color:blue;">static</span>&nbsp;Func&lt;T, bool&gt;&nbsp;<span style="color:#74531f;">AsFunc</span>&lt;<span style="color:#2b91af;">T</span>&gt;(<span style="color:blue;">this</span>&nbsp;ISpecification&lt;T&gt;&nbsp;<span style="color:#1f377f;">specification</span>)
 {
 &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:#8f08c4;">return</span>&nbsp;<span style="color:#1f377f;">candidate</span>&nbsp;=&gt;&nbsp;specification.IsSatisfiedBy(candidate);
 }</pre>


### PR DESCRIPTION
I think I've found a mistake in this post, and I believe this PR fixes it.