### PR TITLE
Add personal URL to existing comment

### DIFF
--- a/_posts/2022-01-17-enumerate-wordle-combinations-with-an-applicative-functor.html
+++ b/_posts/2022-01-17-enumerate-wordle-combinations-with-an-applicative-functor.html
@@ -195,7 +195,7 @@ image_alt: "Wordle after entering TEARS and INURE."
 		Comments
 	</h2>
 	<div class="comment" id="22eb88afa50e4193b8f04e82c55df1cb">
-		<div class="comment-author">Erik De Bonte</div>
+		<div class="comment-author"><a href="https://github.com/debonte">Erik De Bonte</a></div>
 		<div class="comment-content">
 			<p>
 				It's not "better", but here's a similar approach in Python.


### PR DESCRIPTION
@ploeh thanks for suggesting that I use my GitHub profile as the comment author link. That didn't occur to me.