### PR TITLE
Add comment on flattening statically typed lists

### DIFF
--- a/_posts/2022-02-28-can-one-flatten-a-statically-typed-list.html
+++ b/_posts/2022-02-28-can-one-flatten-a-statically-typed-list.html
@@ -141,3 +141,44 @@ l :: Num b =&gt; Tree () b</pre>
 		Likewise, the type of the requested <code>flatten</code> function is <code>toList :: Foldable t =&gt; t a -&gt; [a]</code>.
 	</p>
 </div>
+
+<div id="comments">
+  	<hr/>
+  	<h2 id="comments-header">Comments</h2>
+	<div class="comment" id="c3ed1ef693ce4c5a85c612cdbbc85cd8">
+    		<div class="comment-author">Michael Hensler</div>
+    		<div class="comment-content">
+			<p>
+				He appears to be using JavaScript and the solution is trivial in TypeScript, 
+				so he must not have looked too hard before claiming that statically typed languages cannot handle this scenario.
+				He also kept moving the goalposts (It needs to use list syntax! It needs to support heterogeneous lists!), 
+				but even the most naïve attempt in TypeScript handles those as well.
+			</p>
+			<pre>type Nested<T> = (Nested<T> | T)[];
+
+const flatten = <T>(val: Nested<T>): T[] =>
+  val.reduce(
+    (r: T[], v) => [...r, ...(Array.isArray(v) ? flatten(v) : [v])],
+    []
+  );
+
+const nested = [[[3, 2], 7, [2, 4], 1], 0];
+const result = flatten(nested);
+console.log(result); // [3, 2, 7, 2, 4, 1, 0] 
+
+const silly: Nested<number | string | { name: string }> = [
+  [[3, 2], 1],
+  "cheese",
+  { name: "Fred" },
+];
+const sillyResult = flatten(silly);
+console.log(sillyResult); // [3, 2, 1, "cheese", {"name": "Fred"}]</pre>
+			<p>
+				TypeScript types can also maintain the order of the types of elements in the flattened list.
+				<a href="https://catchts.com/flatten">How to flatten a tuple type in TypeScript?</a> gives a solution capable of handling that,
+				though it is certainly more complex than the version above.
+			</p>
+  		</div>
+    		<div class="comment-date">2022-03-01 03:48 UTC</div>
+  	</div>
+</div>


### PR DESCRIPTION
Is there a way to generate or preview these comments? I tried following examples, but I have no idea if this is right