### PR TITLE
Typo in 2022-05-09-an-either-monad

### DIFF
--- a/_posts/2022-05-09-an-either-monad.html
+++ b/_posts/2022-05-09-an-either-monad.html
@@ -241,7 +241,6 @@ IEither&lt;<span style="color:blue;">string</span>,&nbsp;IEither&lt;<span style=
  
 &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">var</span>&nbsp;<span style="color:#1f377f;">m</span>&nbsp;=&nbsp;f(a);
  
-&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">var</span>&nbsp;<span style="color:#1f377f;">foo</span>&nbsp;=&nbsp;m.SelectMany(g).SelectMany(h);
 &nbsp;&nbsp;&nbsp;&nbsp;Assert.Equal(m.SelectMany(g).SelectMany(h),&nbsp;m.SelectMany(<span style="color:#1f377f;">x</span>&nbsp;=&gt;&nbsp;g(x).SelectMany(h)));
 }</pre>
 	</p>


### PR DESCRIPTION
It seems like variable `foo` in AssociativityLaw function remained unused