### PR TITLE
Division semantics fixes

### DIFF
--- a/_posts/2022-04-25-the-maybe-monad.html
+++ b/_posts/2022-04-25-the-maybe-monad.html
@@ -203,7 +203,7 @@ tags: [Software Design, Functional Programming]
 {
 &nbsp;&nbsp;&nbsp;&nbsp;Func&lt;<span style="color:blue;">int</span>,&nbsp;Maybe&lt;<span style="color:blue;">int</span>&gt;&gt;&nbsp;<span style="color:#1f377f;">@return</span>&nbsp;=&nbsp;<span style="color:#1f377f;">i</span>&nbsp;=&gt;&nbsp;<span style="color:blue;">new</span>&nbsp;Maybe&lt;<span style="color:blue;">int</span>&gt;(i);
 &nbsp;&nbsp;&nbsp;&nbsp;Func&lt;<span style="color:blue;">int</span>,&nbsp;Maybe&lt;<span style="color:blue;">double</span>&gt;&gt;&nbsp;<span style="color:#1f377f;">h</span>&nbsp;=
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:#1f377f;">i</span>&nbsp;=&gt;&nbsp;i&nbsp;!=&nbsp;0&nbsp;?&nbsp;<span style="color:blue;">new</span>&nbsp;Maybe&lt;<span style="color:blue;">double</span>&gt;(1&nbsp;/&nbsp;i)&nbsp;:&nbsp;<span style="color:blue;">new</span>&nbsp;Maybe&lt;<span style="color:blue;">double</span>&gt;();
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:#1f377f;">i</span>&nbsp;=&gt;&nbsp;i&nbsp;!=&nbsp;0&nbsp;?&nbsp;<span style="color:blue;">new</span>&nbsp;Maybe&lt;<span style="color:blue;">double</span>&gt;(1.0&nbsp;/&nbsp;i)&nbsp;:&nbsp;<span style="color:blue;">new</span>&nbsp;Maybe&lt;<span style="color:blue;">double</span>&gt;();
  
 &nbsp;&nbsp;&nbsp;&nbsp;Assert.Equal(@return(a).SelectMany(h),&nbsp;h(a));
 }</pre>
@@ -265,7 +265,7 @@ tags: [Software Design, Functional Programming]
 &nbsp;&nbsp;&nbsp;&nbsp;}
 &nbsp;&nbsp;&nbsp;&nbsp;Func&lt;<span style="color:blue;">int</span>,&nbsp;Maybe&lt;<span style="color:blue;">double</span>&gt;&gt;&nbsp;<span style="color:#1f377f;">g</span>&nbsp;=&nbsp;<span style="color:#1f377f;">i</span>&nbsp;=&gt;&nbsp;Sqrt(i);
 &nbsp;&nbsp;&nbsp;&nbsp;Func&lt;<span style="color:blue;">double</span>,&nbsp;Maybe&lt;<span style="color:blue;">double</span>&gt;&gt;&nbsp;<span style="color:#1f377f;">h</span>&nbsp;=
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:#1f377f;">d</span>&nbsp;=&gt;&nbsp;d&nbsp;==&nbsp;0&nbsp;?&nbsp;<span style="color:blue;">new</span>&nbsp;Maybe&lt;<span style="color:blue;">double</span>&gt;()&nbsp;:&nbsp;<span style="color:blue;">new</span>&nbsp;Maybe&lt;<span style="color:blue;">double</span>&gt;(1&nbsp;/&nbsp;2);
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:#1f377f;">d</span>&nbsp;=&gt;&nbsp;d&nbsp;==&nbsp;0&nbsp;?&nbsp;<span style="color:blue;">new</span>&nbsp;Maybe&lt;<span style="color:blue;">double</span>&gt;()&nbsp;:&nbsp;<span style="color:blue;">new</span>&nbsp;Maybe&lt;<span style="color:blue;">double</span>&gt;(1&nbsp;/&nbsp;d);
  
 &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">var</span>&nbsp;<span style="color:#1f377f;">m</span>&nbsp;=&nbsp;f(a);
  


### PR DESCRIPTION
I think this was the intended (expected) meaning: 1 / int is integer division in C#, so 1/2 == 0. (Although the current version does not prevent the point of the article: Even the piecewise-constant functions fulfill the monad laws…)