### PR TITLE
Update Haskell part of Money Monoid

### DIFF
--- a/_posts/2017-10-16-money-monoid.html
+++ b/_posts/2017-10-16-money-monoid.html
@@ -475,4 +475,39 @@ reduce&#39;&nbsp;bank&nbsp;to&nbsp;exp&nbsp;=&nbsp;Money&nbsp;(reduce&nbsp;bank&
 		</div>
 		<div class="comment-date">2022-02-08 9:01 UTC</div>
 	</div>
+
+  <div class="comment" id="915d063aa2264854ba51f69f160c8683">
+    <div class="comment-author"><a href="https://nikosbaxevanis.com/">Nikos Baxevanis</a></div>
+    <div class="comment-content">
+      <p>
+        After the article was written, a <a href="https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/semigroup-monoid">proposal to make Semigroup as a superclass of Monoid</a> came out and eventually made it into GHC 8+. The changes so that the Haskell part of the article compiles (with GHC 8+) are:
+      </p>
+      <p>
+        <pre>
+{-# LANGUAGE CPP #-}
+import           Data.Semigroup (stimesMonoid)
+#if !MIN_VERSION_base(4,11,0)
+import qualified Data.Semigroup as Semigroup
+#endif
+
+instance Monoid Expression where
+#if !MIN_VERSION_base(4,11,0)
+  mappend =
+    (Semigroup.<>)
+#endif
+  mempty =
+    MoneyIdentity
+
+instance Semigroup Expression where
+  MoneyIdentity <> y =
+    y
+  x <> MoneyIdentity =
+    x
+  x <> y =
+    Sum x y
+        </pre>
+      </p>
+    </div>
+    <div class="comment-date">2022-08-12 5:35 UTC</div>
+  </div>
 </div>


### PR DESCRIPTION
Semigroup as a superclass of Monoid

---

Full example, as a sanity check, not included in the comment:

```hs
-- *** Money monoid
-- https://blog.ploeh.dk/2017/10/16/money-monoid/

{-# LANGUAGE CPP #-}
import           Data.Map.Strict (Map, (!))
import qualified Data.Map.Strict as Map
import           Data.Semigroup (stimesMonoid)
#if !MIN_VERSION_base(4,11,0)
import qualified Data.Semigroup as Semigroup
#endif

instance Monoid Expression where
#if !MIN_VERSION_base(4,11,0)
  mappend =
    (Semigroup.<>)
#endif
  mempty =
    MoneyIdentity

instance Semigroup Expression where
  MoneyIdentity <> y =
    y
  x <> MoneyIdentity =
    x
  x <> y =
    Sum x y

data Expression =
    Money {
        amount :: Int
      , currency :: String
      }
  | Sum {
        augend :: Expression
      , addend :: Expression
      }
  | MoneyIdentity

reduce :: Ord a => Map (String, a) Int -> a -> Expression -> Int
reduce bank to (Money amt cur) =
  let
    rate =
      bank ! (cur, to)
  in
    amt `div` rate
reduce bank to (Sum x y) =
  reduce bank to x + reduce bank to y
reduce _ _ MoneyIdentity =
  0

main :: IO ()
main = do
  -- *** Money monoid
  -- https://blog.ploeh.dk/2017/10/16/money-monoid/
  let
    bank =
      Map.fromList [
          (("CHF", "USD"), 2)
        , (("USD", "USD"), 1)
        ]
    step =
      stimesMonoid (2 :: Integer) $ Sum (Money 5 "USD") (Money 10 "CHF")

  print $ reduce bank "USD" step
```