### PR TITLE
Encapsulation: comment about demonstrating whole idea in one language

### DIFF
--- a/_posts/2022-10-24-encapsulation-in-functional-programming.html
+++ b/_posts/2022-10-24-encapsulation-in-functional-programming.html
@@ -230,3 +230,48 @@ tags: [Functional Programming, F#]
 		Perhaps you can find a functional programmer who might be slightly offended if you suggest that he or she should consider encapsulation. If so, suggest instead that he or she considers the properties of functions and data.
 	</p>
 </div>
+<div class="comment" id="bb616acbc1ac41cb8f937fe7175ce061">
+	<div class="comment-author"><a href="http://www.raboof.com/">Atif Aziz</a></div>
+	<div class="comment-content">
+		<p>
+			I wonder what's the goal of illustrating OOP-ish examples exclusively in C# and FP-ish ones in F# when you could stick to just one language for the reader. It might not always be as effective depending on the topic, but for encapsulation and the examples shown in this article, a C# version would read just as effective as an F# one. I mean when you get round to making your points in the <strong>Immutable Table</strong> section of your article, you could demonstrate the ideas with a C# version that's nearly identical to and reads as succinct as the F# version:
+		</p>
+<pre><span style="color:gray;">#nullable</span>&nbsp;<span style="color:gray;">enable</span>
+ 
+<span style="color:blue;">readonly</span>&nbsp;<span style="color:blue;">record</span>&nbsp;<span style="color:blue;">struct</span>&nbsp;<span style="color:darkblue;">Reservation</span>(<span style="color:blue;">int</span>&nbsp;<span style="color:#1f377f;">Quantity</span>);
+<span style="color:blue;">abstract</span>&nbsp;<span style="color:blue;">record</span>&nbsp;<span style="color:darkblue;">Table</span>;
+<span style="color:blue;">record</span>&nbsp;<span style="color:darkblue;">StandardTable</span>(<span style="color:blue;">int</span>&nbsp;<span style="color:#1f377f;">Capacity</span>,&nbsp;<span style="color:darkblue;">Reservation</span>?&nbsp;<span style="color:#1f377f;">Reservation</span>):&nbsp;<span style="color:darkblue;">Table</span>;
+<span style="color:blue;">record</span>&nbsp;<span style="color:darkblue;">CommunalTable</span>(<span style="color:blue;">int</span>&nbsp;<span style="color:#1f377f;">Capacity</span>,&nbsp;<span style="color:red;">ImmutableArray</span>&lt;<span style="color:darkblue;">Reservation</span>&gt;&nbsp;<span style="color:#1f377f;">Reservations</span>):&nbsp;<span style="color:darkblue;">Table</span>;
+ 
+<span style="color:blue;">static</span>&nbsp;<span style="color:blue;">class</span>&nbsp;<span style="color:darkblue;">TableModule</span>
+{
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">public</span>&nbsp;<span style="color:blue;">static</span>&nbsp;<span style="color:darkblue;">StandardTable</span>?&nbsp;<span style="color:darkcyan;">Standard</span>(<span style="color:blue;">int</span>&nbsp;<span style="color:#1f377f;">capacity</span>)&nbsp;=&gt;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0&nbsp;&lt;&nbsp;capacity&nbsp;?&nbsp;<span style="color:blue;">new</span>&nbsp;<span style="color:darkblue;">StandardTable</span>(capacity,&nbsp;<span style="color:blue;">null</span>)&nbsp;:&nbsp;<span style="color:blue;">null</span>;
+ 
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">public</span>&nbsp;<span style="color:blue;">static</span>&nbsp;<span style="color:darkblue;">CommunalTable</span>?&nbsp;<span style="color:darkcyan;">Communal</span>(<span style="color:blue;">int</span>&nbsp;<span style="color:#1f377f;">capacity</span>)&nbsp;=&gt;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0&nbsp;&lt;&nbsp;capacity&nbsp;?&nbsp;<span style="color:blue;">new</span>&nbsp;<span style="color:darkblue;">CommunalTable</span>(capacity,&nbsp;<span style="color:red;">ImmutableArray</span>&lt;<span style="color:darkblue;">Reservation</span>&gt;.Empty)&nbsp;:&nbsp;<span style="color:blue;">null</span>;
+ 
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">public</span>&nbsp;<span style="color:blue;">static</span>&nbsp;<span style="color:blue;">int</span>&nbsp;<span style="color:darkcyan;">RemainingSeats</span>(<span style="color:blue;">this</span>&nbsp;<span style="color:darkblue;">Table</span>&nbsp;<span style="color:#1f377f;">table</span>)&nbsp;=&gt;&nbsp;table&nbsp;<span style="color:#8f08c4;">switch</span>
+&nbsp;&nbsp;&nbsp;&nbsp;{
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:darkblue;">StandardTable</span>&nbsp;{&nbsp;<span style="color:purple;">Reservation</span>:&nbsp;<span style="color:blue;">null</span>&nbsp;}&nbsp;t&nbsp;=&gt;&nbsp;t.<span style="color:purple;">Capacity</span>,
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:darkblue;">StandardTable</span>&nbsp;=&gt;&nbsp;0,
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:darkblue;">CommunalTable</span>&nbsp;<span style="color:#1f377f;">t</span>&nbsp;=&gt;&nbsp;t.<span style="color:purple;">Capacity</span>&nbsp;-&nbsp;t.<span style="color:purple;">Reservations</span>.Sum(<span style="color:#1f377f;">r</span>&nbsp;=&gt;&nbsp;r.Quantity)
+&nbsp;&nbsp;&nbsp;&nbsp;};
+ 
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">public</span>&nbsp;<span style="color:blue;">static</span>&nbsp;<span style="color:darkblue;">Table</span>?&nbsp;<span style="color:darkcyan;">Reserve</span>(<span style="color:blue;">this</span>&nbsp;<span style="color:darkblue;">Table</span>&nbsp;<span style="color:#1f377f;">table</span>,&nbsp;<span style="color:darkblue;">Reservation</span>&nbsp;<span style="color:#1f377f;">r</span>)&nbsp;=&gt;&nbsp;table&nbsp;<span style="color:#8f08c4;">switch</span>
+&nbsp;&nbsp;&nbsp;&nbsp;{
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:darkblue;">StandardTable</span>&nbsp;<span style="color:#1f377f;">t</span>&nbsp;<span style="color:#8f08c4;">when</span>&nbsp;r.<span style="color:purple;">Quantity</span>&nbsp;&lt;=&nbsp;t.<span style="color:darkcyan;">RemainingSeats</span>()&nbsp;=&gt;&nbsp;t&nbsp;<span style="color:blue;">with</span>&nbsp;{&nbsp;<span style="color:purple;">Reservation</span>&nbsp;=&nbsp;r&nbsp;},
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:darkblue;">CommunalTable</span>&nbsp;<span style="color:#1f377f;">t</span>&nbsp;<span style="color:#8f08c4;">when</span>&nbsp;r.<span style="color:purple;">Quantity</span>&nbsp;&lt;=&nbsp;t.<span style="color:darkcyan;">RemainingSeats</span>()&nbsp;=&gt;&nbsp;t&nbsp;<span style="color:blue;">with</span>&nbsp;{&nbsp;<span style="color:purple;">Reservations</span>&nbsp;=&nbsp;t.<span style="color:purple;">Reservations</span>.Add(r)&nbsp;},
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:blue;">_</span>&nbsp;=&gt;&nbsp;<span style="color:blue;">null</span>,
+&nbsp;&nbsp;&nbsp;&nbsp;};
+}
+</pre>
+		<p>
+			This way, I can just point someone to your article for enlightenment, &#x1F609; but not leave them feeling frustrated that they need F# to (practice and) model around data instead of state mutating objects. It might still be worthwhile to show an F# version to draw the similarities and also call out some differences; like <code>Table</code> being a true discriminated union in F#, and while it appears to be emulated in C#, they desugar to the same thing in terms of CLR types and hierarchies.
+		</p>
+		<p>
+			By the way, in the C# example above, I modeled the standard table variant differently because if it can hold only one reservation at a time then the model should reflect that.
+		</p>
+	</div>
+	<div class="comment-date">2022-10-27 16:09 UTC</div>
+</div>


### PR DESCRIPTION
This PR adds the following comment to [Encapsulation in Functional Programming](https://blog.ploeh.dk/2022/10/24/encapsulation-in-functional-programming/):

> I wonder what's the goal of illustrating OOP-ish examples exclusively in C# and FP-ish ones in F# when you could stick to just one language for the reader. It might not always be as effective depending on the topic, but for encapsulation and the examples shown in this article, a C# version would read just as effective as an F# one. I mean when you get round to making your points in the **Immutable Table** section of your article, you could demonstrate the ideas with a C# version that's nearly identical to and reads as succinct as the F# version:
>
> ```c#
> #nullable enable
>
> readonly record struct Reservation(int Quantity);
> abstract record Table;
> record StandardTable(int Capacity, Reservation? Reservation): Table;
> record CommunalTable(int Capacity, ImmutableArray<Reservation> Reservations): Table;
> 
> static class TableModule
> {
>     public static StandardTable? Standard(int capacity) =>
>         0 < capacity ? new StandardTable(capacity, null) : null;
> 
>     public static CommunalTable? Communal(int capacity) =>
>         0 < capacity ? new CommunalTable(capacity, ImmutableArray<Reservation>.Empty) : null;
> 
>     public static int RemainingSeats(this Table table) => table switch
>     {
>         StandardTable { Reservation: null } t => t.Capacity,
>         StandardTable => 0,
>         CommunalTable t => t.Capacity - t.Reservations.Sum(r => r.Quantity)
>     };
> 
>     public static Table? Reserve(this Table table, Reservation r) => table switch
>     {
>         StandardTable t when r.Quantity <= t.RemainingSeats() => t with { Reservation = r },
>         CommunalTable t when r.Quantity <= t.RemainingSeats() => t with { Reservations = t.Reservations.Add(r) },
>         _ => null,
>     };
> }
> ```
>
> This way, I can just point someone to your article for enlightenment, &#x1F609; but not leave them feeling frustrated that they need F# to (practice and) model around data instead of state mutating objects. It might still be worthwhile to show an F# version to draw the similarities and also call out some differences; like `Table` being a true discriminated union in F#, and while it appears to be emulated in C#, they desugar to the same thing in terms of CLR types and hierarchies.
>
> By the way, in the C# example above, I modeled the standard table variant differently because if it can hold only one reservation at a time then the model should reflect that.
