### PR TITLE
Encapsulation: comment about encapsulating `Table` subtypes

### DIFF
--- a/_posts/2022-10-24-encapsulation-in-functional-programming.html
+++ b/_posts/2022-10-24-encapsulation-in-functional-programming.html
@@ -297,4 +297,74 @@ tags: [Functional Programming, F#]
 		</div>
 		<div class="comment-date">2022-10-28 8:50 UTC</div>
 	</div>
+
+<div class="comment" id="a7b4d4d0dcc8432fb3b49cb7189d8123">
+	<div class="comment-author"><a href="https://github.com/sebastianfrelle">Sebastian Frelle Koch</a></div>
+	<div class="comment-content">
+    <p>I took your idea, Atif, and wrote something that I think is more congruent with the example <a href="#78027bc1d1414c2fa3604a68c9df6418">here</a>. In short, I’m</p>
+
+    <ul>
+      <li>using polymorphism to avoid having to switch over the Table type</li>
+      <li>hiding subtypes of Table to simplify the interface.</li>
+    </ul>
+
+    <p>Here's the code:</p>
+
+    <div class="language-cs highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="err">#</span><span class="n">nullable</span> <span class="n">enable</span>
+
+<span class="k">using</span> <span class="nn">System.Collections.Immutable</span><span class="p">;</span>
+
+<span class="k">readonly</span> <span class="n">record</span> <span class="k">struct</span> <span class="nc">Reservation</span><span class="p">(</span><span class="kt">int</span> <span class="n">Quantity</span><span class="p">);</span>
+<span class="k">abstract</span> <span class="n">record</span> <span class="n">Table</span>
+<span class="p">{</span>
+    <span class="k">public</span> <span class="k">abstract</span> <span class="n">Table</span><span class="p">?</span> <span class="nf">Reserve</span><span class="p">(</span><span class="n">Reservation</span> <span class="n">r</span><span class="p">);</span>
+    <span class="k">public</span> <span class="k">abstract</span> <span class="kt">int</span> <span class="nf">RemainingSeats</span><span class="p">();</span>
+
+    <span class="k">public</span> <span class="k">static</span> <span class="n">Table</span><span class="p">?</span> <span class="nf">Standard</span><span class="p">(</span><span class="kt">int</span> <span class="n">capacity</span><span class="p">)</span> <span class="p">=&gt;</span> 
+        <span class="n">capacity</span> <span class="p">&gt;</span> <span class="m">0</span> <span class="p">?</span> <span class="k">new</span> <span class="nf">StandardTable</span><span class="p">(</span><span class="n">capacity</span><span class="p">,</span> <span class="k">null</span><span class="p">)</span> <span class="p">:</span> <span class="k">null</span><span class="p">;</span>
+
+    <span class="k">public</span> <span class="k">static</span> <span class="n">Table</span><span class="p">?</span> <span class="nf">Communal</span><span class="p">(</span><span class="kt">int</span> <span class="n">capacity</span><span class="p">)</span> <span class="p">=&gt;</span> 
+        <span class="n">capacity</span> <span class="p">&gt;</span> <span class="m">0</span> <span class="p">?</span> <span class="k">new</span> <span class="nf">CommunalTable</span><span class="p">(</span>
+            <span class="n">capacity</span><span class="p">,</span>
+            <span class="n">ImmutableArray</span><span class="p">&lt;</span><span class="n">Reservation</span><span class="p">&gt;.</span><span class="n">Empty</span><span class="p">)</span> <span class="p">:</span> <span class="k">null</span><span class="p">;</span>
+
+    <span class="k">private</span> <span class="n">record</span> <span class="nf">StandardTable</span><span class="p">(</span><span class="kt">int</span> <span class="n">Capacity</span><span class="p">,</span> <span class="n">Reservation</span><span class="p">?</span> <span class="n">Reservation</span><span class="p">)</span> <span class="p">:</span> <span class="n">Table</span>
+    <span class="p">{</span>
+        <span class="k">public</span> <span class="k">override</span> <span class="n">Table</span><span class="p">?</span> <span class="nf">Reserve</span><span class="p">(</span><span class="n">Reservation</span> <span class="n">r</span><span class="p">)</span> <span class="p">=&gt;</span> <span class="nf">RemainingSeats</span><span class="p">()</span> <span class="k">switch</span>
+        <span class="p">{</span>
+            <span class="kt">var</span> <span class="n">seats</span> <span class="n">when</span> <span class="n">seats</span> <span class="p">&gt;=</span> <span class="n">r</span><span class="p">.</span><span class="n">Quantity</span> <span class="p">=&gt;</span> <span class="k">this</span> <span class="n">with</span> <span class="p">{</span> <span class="n">Reservation</span> <span class="p">=</span> <span class="n">r</span> <span class="p">},</span>
+            <span class="n">_</span> <span class="p">=&gt;</span> <span class="k">null</span><span class="p">,</span>
+        <span class="p">};</span>
+
+        <span class="k">public</span> <span class="k">override</span> <span class="kt">int</span> <span class="nf">RemainingSeats</span><span class="p">()</span> <span class="p">=&gt;</span> <span class="n">Reservation</span> <span class="k">switch</span>
+        <span class="p">{</span>
+            <span class="k">null</span> <span class="p">=&gt;</span> <span class="n">Capacity</span><span class="p">,</span>
+            <span class="n">_</span> <span class="p">=&gt;</span> <span class="m">0</span><span class="p">,</span>
+        <span class="p">};</span>
+    <span class="p">}</span>
+
+    <span class="k">private</span> <span class="n">record</span> <span class="nf">CommunalTable</span><span class="p">(</span>
+        <span class="kt">int</span> <span class="n">Capacity</span><span class="p">,</span> 
+        <span class="n">ImmutableArray</span><span class="p">&lt;</span><span class="n">Reservation</span><span class="p">&gt;</span> <span class="n">Reservations</span><span class="p">)</span> <span class="p">:</span> <span class="n">Table</span>
+    <span class="p">{</span>
+        <span class="k">public</span> <span class="k">override</span> <span class="n">Table</span><span class="p">?</span> <span class="nf">Reserve</span><span class="p">(</span><span class="n">Reservation</span> <span class="n">r</span><span class="p">)</span> <span class="p">=&gt;</span> <span class="nf">RemainingSeats</span><span class="p">()</span> <span class="k">switch</span>
+        <span class="p">{</span>
+            <span class="kt">var</span> <span class="n">seats</span> <span class="n">when</span> <span class="n">seats</span> <span class="p">&gt;=</span> <span class="n">r</span><span class="p">.</span><span class="n">Quantity</span> <span class="p">=&gt;</span>
+                <span class="k">this</span> <span class="n">with</span> <span class="p">{</span> <span class="n">Reservations</span> <span class="p">=</span> <span class="n">Reservations</span><span class="p">.</span><span class="nf">Add</span><span class="p">(</span><span class="n">r</span><span class="p">)</span> <span class="p">},</span>
+            <span class="n">_</span> <span class="p">=&gt;</span> <span class="k">null</span><span class="p">,</span>
+        <span class="p">};</span>
+
+        <span class="k">public</span> <span class="k">override</span> <span class="kt">int</span> <span class="nf">RemainingSeats</span><span class="p">()</span> <span class="p">=&gt;</span> 
+            <span class="n">Capacity</span> <span class="p">-</span> <span class="n">Reservations</span><span class="p">.</span><span class="nf">Sum</span><span class="p">(</span><span class="n">r</span> <span class="p">=&gt;</span> <span class="n">r</span><span class="p">.</span><span class="n">Quantity</span><span class="p">);</span>
+    <span class="p">}</span>
+<span class="p">}</span>
+    </code></pre></div></div>
+
+    <p>I’d love to hear your thoughts on this approach. I think that one of its weaknesses is that calls to <code class="language-plaintext highlighter-rouge">Table.Standard()</code> and <code class="language-plaintext highlighter-rouge">Table.Communal()</code> will yield two instances of <code class="language-plaintext highlighter-rouge">Table</code> that can never be equal. For instance, <code class="language-plaintext highlighter-rouge">Table.Standard(4) != Table.Communal(4)</code>, even though they’re both of type <code class="language-plaintext highlighter-rouge">Table?</code> and have the same number of seats.
+    </p>
+
+    <p>
+    Calling <code class="language-plaintext highlighter-rouge">GetType()</code> on each of the instances reveals that their types are actually <code class="language-plaintext highlighter-rouge">Table+StandardTable</code> and <code class="language-plaintext highlighter-rouge">Table+CommunalTable</code> respectively; however, this isn't transparent to callers. Another solution might be to expose the <code class="language-plaintext highlighter-rouge">Table</code> subtypes and give them private constructors &ndash; I just like the simplicity of not exposing the individual types of tables the same way you’re doing <a href="#b37e173371f249d99f80d12d64b2bee2">here</a>, Mark.</p>
+	</div>
+	<div class="comment-date">2022-11-29 11:28 UTC</div>
 </div>


### PR DESCRIPTION
This PR adds a comment to https://blog.ploeh.dk/2022/10/24/encapsulation-in-functional-programming/ about encapsulating the subtypes to `Table` as outlined in [atifaziz' comment.](https://github.com/ploeh/ploeh.github.com/pull/849#issue-1425907896)

I apologize for the messy code; I couldn't get Jekyll to build the page with proper syntax highlighting or formatting. I'll make changes if necessary.