### PR TITLE
Fix two typos in "When do tests fail?"

### DIFF
--- a/_posts/2022-12-12-when-do-tests-fail.html
+++ b/_posts/2022-12-12-when-do-tests-fail.html
@@ -82,7 +82,7 @@ tags: [Unit Testing]
 		First, of course, there's the lack of information about the problem. Here, that's a real problem. As I understand it, it makes it harder to reproduce the problem in a development environment.
 	</p>
 	<p>
-		Next, there's long cycle times, which I interpret as significant time may pass from you attempt a fix until you can actually observe whether or not it worked. Josh McKinney doesn't say how long, but I wouldn't surprised if it was measured in days. At least, if the cycle time is measured in days, I can see how this is a problem.
+		Next, there's long cycle times, which I interpret as significant time may pass from when you attempt a fix until you can actually observe whether or not it worked. Josh McKinney doesn't say how long, but I wouldn't surprised if it was measured in days. At least, if the cycle time is measured in days, I can see how this is a problem.
 	</p>
 	<p>
 		Finally, there's the observation that "some tests start failing intermittently". This was the remark that caught my attention. How often does that happen?
@@ -166,7 +166,7 @@ tags: [Unit Testing]
 		With TDD and CI/CD you mostly look at a unit test when you write it, or if some regression test fails because you changed some code (perhaps in response to a test you just wrote). Your test suite may have hundreds or thousands of tests. Most of these pass every time you run the test suite. That's the normal state of affairs.
 	</p>
 	<p>
-		In other circumstances, you may have Erratic Tests that fail unpredictably. You should make it priority to stop that, but as part of that process, you may need good assertion messages and good test names.
+		In other circumstances, you may have Erratic Tests that fail unpredictably. You should make it a priority to stop that, but as part of that process, you may need good assertion messages and good test names.
 	</p>
 	<p>
 		Different circumstances call for different reactions, so what works well in one situation may be a liability in other situations. I hope that this article has shed a little light on the forces you may want to consider.


### PR DESCRIPTION
Added "when" to line 85, and added "a" to line 169.