### PR TITLE
2013/10/23/mocks-for-commands-stubs-for-queries Possible fix for example code

### DIFF
--- a/_posts/2013-10-23-mocks-for-commands-stubs-for-queries.html
+++ b/_posts/2013-10-23-mocks-for-commands-stubs-for-queries.html
@@ -310,7 +310,7 @@ tags: [Unit Testing]
 {
 &nbsp;&nbsp;&nbsp; <span style="color: blue;">var</span> u = <span style="color: blue;">this</span>.userRepository.Read(userId);
 &nbsp;&nbsp;&nbsp; <span style="color: blue;">if</span> (u.Id == 0)
-&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; <span style="color: blue;">this</span>.userRepository.Create(1234);
+&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; <span style="color: blue;">this</span>.userRepository.Create(userId);
 &nbsp;&nbsp;&nbsp; <span style="color: blue;">return</span> u;
 }</pre>
 	</p>


### PR DESCRIPTION
Hello, @ploeh 

I'm, not sure if it was intentional from your side, but it looks like there is minor issue in code in https://blog.ploeh.dk/2013/10/23/mocks-for-commands-stubs-for-queries/ in next section

< cut from the mentioned article >

# Data Flow Verification 

... (skipped)

With the Stub verifying the Query (GetUserReturnsCorrectValue), and the other test that uses a Mock to verify a Command (UserIsSavedIfItDoesNotExist), the final implementation is:

```
public User GetUser(int userId)
{
    var u = this.userRepository.Read(userId);
    if (u.Id == 0)
        this.userRepository.Create(1234);
    return u;
}
```
< cut from the mentioned article >

where `1234` is used as `user id` in `userRepository.Create()`. 

Also, it's interesting, that this isssue is not caught by unit test mentioned in the same section, that makes me worry about the whole story. And yes, I'm aware that `this.userRepository.Create(1234);` is a `command`, not a `query`, and thus it has to be tested by `mock`, not a `stub`. If possible, I'd like this fact to be (at least) mentioned separately. Or (minimal efforts principle) "fixed" (hiding the problem, in fact) by changes proposed here.

Sorry for necroposting, hope it was valuable.