### PR TITLE
Add open graph meta tags

### DIFF
--- a/_includes/themes/ploeh/default.html
+++ b/_includes/themes/ploeh/default.html
@@ -46,6 +46,13 @@
     {% if page.image %}<meta name="twitter:image" content="{{ site.url }}{{ page.image }}" />{% else %}<meta name="twitter:image" content="{{ site.url }}{{ ASSET_PATH }}/images/favicons/favicon.png" />{% endif %}
     {% if page.image_alt %}<meta name="twitter:image:alt" content="{{ page.image_alt }}" />{% endif %}
 
+    <!-- open graph -->
+    <meta name="og:url" content="{{ page.url | absolute_url }}" />
+    <meta name="og:title" content="{{ page.title }}" />
+    {% if page.description %}<meta name="og:description" content="{{ page.description }}">{% endif %}
+    {% if page.image %}<meta name="og:image" content="{{ site.url }}{{ page.image }}" />{% else %}<meta name="og:image" content="{{ site.url }}{{ ASSET_PATH }}/images/favicons/favicon.png" />{% endif %}
+    {% if page.image_alt %}<meta name="og:image:alt" content="{{ page.image_alt }}" />{% endif %}
+
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-833CB0M585"></script>
     <script>


### PR DESCRIPTION
Pages already have the twitter specific tags that enhance the way the link preview is rendered if a link is posted there, but they are not supported by all platforms. This adds the corresponding open graph tags that serve the same function on other sites (including Mastodon which is where I noticed this discrepancy)