### PR TITLE
Precise:  Serialization w/ & without Reflection

### DIFF
--- a/_posts/2023-12-04-serialization-with-and-without-reflection.html
+++ b/_posts/2023-12-04-serialization-with-and-without-reflection.html
@@ -156,3 +156,44 @@ image_alt: "Bar seating at Ernst, Berlin."
         <strong>Next:</strong> Serializing restaurant tables in Haskell.
     </p>
 </div>
+
+<div id="comments">
+    <hr>
+    <h2 id="comments-header">
+        Comments
+    </h2>
+    <div class="comment" id="db4a9a94452a1237bf71989561dfd947">
+        <div class="comment-author"><a href="#db4a9a94452a1237bf71989561dfd947">gdifolco</a></div>
+        <div class="comment-content">
+          <q>
+            <i>
+                I'll start with <a href="https://www.haskell.org/">Haskell</a>, since that language doesn't have run-time Reflection.
+            </i>
+          </q>
+          <p>
+            Haskell (the language) does not provide primitives to access to data representation <i>per-se</i>, during the compilation GHC (the compiler) erase a lot of information (more or less depending on the profiling flags) in order to provide to the run-time system (RTS) a minimal "bytecode".
+          </p>
+          <p>
+            That being said, provide three ways to deal structurally with values:
+            <ul>
+              <li><a href="https://wiki.haskell.org/Template_Haskell">TemplateHaskell</a>: give the ability to rewrite the AST at compile-time</li>
+              <li><a href="https://hackage.haskell.org/package/base-4.19.0.0/docs/GHC-Generics.html#t:Generic">Generics</a>: give the ability to have a type-level representation of a type structure</li>
+              <li><a href="https://hackage.haskell.org/package/base-4.19.0.0/docs/Type-Reflection.html#t:Typeable">Typeable</a>: give the ability to have a value-level representation of a type structure</li>
+            </ul>
+          </p>
+          <p>
+            <i>Template Haskell</i> is low-level as it implies to deal with the AST, it is also harder to debug as, in order to be evaluated, the main compilation phase is stopped, then the <i>Template Haskell</i> code is ran, and finally the main compilation phase continue. It also causes compilation cache issues.
+          </p>
+          <p>
+            <i>Generics</i> take type's structure and generate a representation at type-level, the main idea is to be able to go back and forth between the type and its representation, so you can define so behavior over a structure, the good thing being that, since the representation is known at compile-time, many optimizations can be done. On complex types it tends to slow-down compilation and produce larger-than-usual binaries, it is generraly the way libraries are implemented.
+          </p>
+          <p>
+            <i>Typeable</i> is a purely value-level type representation, you get only on type whatever the type structure is, it is generally used when you have "dynamic" types, it provides safe ways to do coercion.
+          </p>
+          <p>
+            Haskell tends to push as much things as possible in compile-time, this may explain this tendency.
+          </p>
+        </div>
+        <div class="comment-date">2023-10-23 18:05 UTC</div>
+    </div>
+</div>


### PR DESCRIPTION
Haskell has reflection through [Typeable](https://hackage.haskell.org/package/base-4.19.0.0/docs/Data-Typeable.html#t:Typeable), however it's not widely use.

I tend to use it at the boundaries of my Domain, when I have runtime types uncertainty.

I agree that they are not used for serialization (as far as I know), and that the RTS does not have enough knowledge on the types it deals with (and we cannot access to what it knows).